### PR TITLE
Act using root policy, when given specific uid set by administrator

### DIFF
--- a/services/auth/src/middlewares/auth.ts
+++ b/services/auth/src/middlewares/auth.ts
@@ -1,11 +1,12 @@
 import { Middleware, Next, ParameterizedContext } from 'koa';
 import { KoaContextState } from '../types/koa';
-import { appStage } from '../util';
+import { appStage, env } from '../util';
 import { firebaseProjectName, initializeFirebaseAdmin } from '../util/firebase';
 import { AppStage } from '../types/env';
-import { IamPolicy, IamPolicyObject } from '../util/iam';
+import { generateRootPolicy, IamPolicy, IamPolicyObject } from '../util/iam';
 import Exception, { ExceptionCode } from '../util/error';
 import { TokenSubject, verifyToken } from '../util/token';
+import service from '../services';
 
 const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const bearerToken = /^Bearer ([a-zA-Z0-9\-_.]+)$/i;
@@ -99,6 +100,21 @@ const auth = (): Middleware<KoaContextState> => {
 
     ctx.state.uid = uid;
     ctx.state.policy = policy;
+
+    try {
+      /* try to override with root policy if root uid feature is enabled */
+      const rootUid =
+        appStage() === AppStage.local
+          ? env('ROOT_UID')
+          : await service().secret().get('ROOT_UID');
+
+      if (rootUid === uid) {
+        ctx.state.policy = generateRootPolicy();
+        ctx.state.logger.info(`user ${uid} executing as root policy`);
+      }
+    } catch (e) {
+      /* pass */
+    }
 
     await next();
   };

--- a/services/auth/src/routes/index.test.ts
+++ b/services/auth/src/routes/index.test.ts
@@ -1,5 +1,11 @@
 import { SuperTest, Test } from 'supertest';
-import { Connection, createConnection, getRepository } from 'typeorm';
+import {
+  Connection,
+  createConnection,
+  DeepPartial,
+  getRepository,
+} from 'typeorm';
+import * as uuid from 'uuid';
 import {
   HTTP_BAD_REQUEST,
   HTTP_CREATED,
@@ -8,7 +14,7 @@ import {
   HTTP_UNAUTHORIZED,
 } from '../const';
 import Policy from '../entities/policy';
-import User from '../entities/user';
+import User, { AuthProvider, UserState } from '../entities/user';
 import UserProfile from '../entities/userProfile';
 import { cleanDatabase, closeServer, openServer, ormConfigs } from '../test';
 import { firebaseCustomIdToken } from '../test/util';
@@ -22,6 +28,62 @@ let request: SuperTest<Test>;
 
 // eslint-disable-next-line no-console
 console.log = jest.fn();
+
+const defaultUserPolicyString = JSON.stringify(
+  generateDefaultUserPolicy().toJsonObject()
+);
+
+const setupUser = async () => {
+  return connection.transaction(async (manager) => {
+    const userProfile = await manager
+      .createQueryBuilder(UserProfile, 'user_profile')
+      .insert()
+      .values({ name: `test` })
+      .returning(UserProfile.columns)
+      .execute()
+      .then((insertResult) =>
+        UserProfile.fromRawColumns(
+          (insertResult.raw as DeepPartial<UserProfile>[])[0],
+          { connection }
+        )
+      );
+
+    const adminerPolicy = await manager
+      .createQueryBuilder(Policy, 'policy')
+      .insert()
+      .values({
+        name: 'DefaultUserPolicy',
+        value: defaultUserPolicyString,
+      })
+      .returning(Policy.columns)
+      .execute()
+      .then((insertResult) =>
+        Policy.fromRawColumns((insertResult.raw as DeepPartial<Policy>[])[0], {
+          connection,
+        })
+      );
+
+    const user = await manager
+      .createQueryBuilder(User, 'user')
+      .insert()
+      .values({
+        fkUserProfileId: userProfile.id,
+        fkPolicyId: adminerPolicy.id,
+        state: UserState.active,
+        provider: AuthProvider.custom,
+        providerUserId: `test`,
+      })
+      .returning(User.columns)
+      .execute()
+      .then((insertResult) =>
+        User.fromRawColumns((insertResult.raw as DeepPartial<User>[])[0], {
+          connection,
+        })
+      );
+
+    return user.id;
+  });
+};
 
 beforeAll(async () => {
   connection = await createConnection(
@@ -193,5 +255,42 @@ describe('General - GET /token', () => {
 
     const user = await getRepository(User).findOne(userId);
     expect(user?.lastSignedAt).toBeTruthy();
+  });
+});
+
+describe('Overriding with root user', () => {
+  test('Can override own policy as root user', async () => {
+    const testUid = await setupUser();
+
+    process.env.ROOT_UID = testUid;
+
+    await request
+      .get('/policy/count')
+      .set({ 'x-debug-user-id': testUid })
+      .expect(HTTP_OK);
+  });
+
+  test('Cannot override policy when ROOT_UID is given different', async () => {
+    const testUid = await setupUser();
+
+    process.env.ROOT_UID = uuid.v4();
+
+    await request
+      .get('/policy/count')
+      .set({ 'x-debug-user-id': testUid })
+      .expect(HTTP_FORBIDDEN);
+  });
+
+  test('Prints logs when acting as root user', async () => {
+    const testUid = await setupUser();
+
+    process.env.ROOT_UID = testUid;
+
+    await request.get('/policy/count').set({ 'x-debug-user-id': testUid });
+
+    // eslint-disable-next-line no-console
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining(`user ${testUid} executing as root policy`)
+    );
   });
 });

--- a/services/auth/src/services/secret/ssm.ts
+++ b/services/auth/src/services/secret/ssm.ts
@@ -5,26 +5,20 @@ import { env } from '../../util';
 export default class SsmSecretStorage implements SecretStorage {
   private ssm: SSM;
 
-  private parameters?: SSM.ParameterList;
-
   constructor() {
     this.ssm = new SSM();
   }
 
   async get(key: string): Promise<string> {
-    if (!this.parameters) {
-      const { Parameters: parameters } = await this.ssm
-        .getParametersByPath({
-          Path: `/${env('APP_NAME')}/${env('APP_STAGE')}`,
-          WithDecryption: true,
-        })
-        .promise();
-      this.parameters = parameters;
-    }
+    const { Parameters: parameters } = await this.ssm
+      .getParametersByPath({
+        Path: `/${env('APP_NAME')}/${env('APP_STAGE')}`,
+        WithDecryption: true,
+      })
+      .promise();
 
-    const maybeValue = this.parameters?.find((param) =>
-      param.Name?.includes(key)
-    )?.Value;
+    const maybeValue = parameters?.find((param) => param.Name?.includes(key))
+      ?.Value;
 
     if (!maybeValue) {
       throw Error(`SSM parameter of key ${key} is not set`);

--- a/services/auth/src/util/iam/index.ts
+++ b/services/auth/src/util/iam/index.ts
@@ -2,6 +2,7 @@ export { default as IamRule, IamRuleObject } from './rule';
 export {
   default as IamPolicy,
   generateDefaultUserPolicy,
+  generateRootPolicy,
   IamPolicyObject,
 } from './policy';
 export { default as OperationSchema, OperationSchemaObject } from './schema';

--- a/services/auth/src/util/iam/policy.ts
+++ b/services/auth/src/util/iam/policy.ts
@@ -117,3 +117,11 @@ export const generateDefaultUserPolicy = () =>
       }),
     ],
   });
+
+export const generateRootPolicy = () =>
+  new IamPolicy({
+    rules: [
+      new IamRule({ operationType: OperationType.query, operation: '*' }),
+      new IamRule({ operationType: OperationType.mutation, operation: '*' }),
+    ],
+  });


### PR DESCRIPTION
 - Administrator can set `ROOT_UID` SSM parameter at AWS console (in `beta`, `release` stage), or set `ROOT_UID` environment variable (in `local` stage). If the parameter is not set, this feature is not applied.
 - `auth` middleware compares the user's current id and `ROOT_UID`. If the id matches, the policy of the user is overridden to that of root user.
- This feature should be applied temporarily, when configuring the service at the start. `ROOT_UID` should be handled carefully.