### PR TITLE
Add "pinned" column to Place schema

### DIFF
--- a/services/http-api/README.md
+++ b/services/http-api/README.md
@@ -49,7 +49,8 @@ Retrieve data of a single cafe.
       "id": "11111111-1111-1111-1111-111111111111",
       "createdAt": "2020-01-01T00:00:00.000Z",
       "updatedAt": "2020-01-01T00:00:00.000Z",
-      "name": "판교"
+      "name": "판교",
+      "pinned": true
     },
     "metadata": {
       "hour": "09:00 ~ 19:00"
@@ -112,7 +113,8 @@ The follows describe the detailed response schema.
       id: [uuid],
       createdAt: [ISODateString],
       updatedAt: [ISODateString],
-      name: string
+      name: string,
+      pinned: boolean
     },
     metadata: JSON,
     state: "active" | "hidden",
@@ -187,7 +189,8 @@ Retrieves a list of cafe as a feed, which is selected randomly (for now), among 
           "id": "11111111-1111-1111-1111-111111111111",
           "createdAt": "2020-01-01T00:00:00.000Z",
           "updatedAt": "2020-01-01T00:00:00.000Z",
-          "name": "판교"
+          "name": "판교",
+          "pinned": true
         },
         "metadata": {
           "hour": "09:00 ~ 19:00"
@@ -332,7 +335,8 @@ Retrieve a list of cafes.
           "id": "11111111-1111-1111-1111-111111111111",
           "createdAt": "2020-01-01T00:00:00.000Z",
           "updatedAt": "2020-01-01T00:00:00.000Z",
-          "name": "판교"
+          "name": "판교",
+          "pinned": true
         },
         "metadata": {
           "hour": "09:00 ~ 19:00"
@@ -388,7 +392,8 @@ Retrieve a list of cafes.
           "id": "11111111-1111-1111-1111-111111111111",
           "createdAt": "2020-01-01T00:00:00.000Z",
           "updatedAt": "2020-01-01T00:00:00.000Z",
-          "name": "판교"
+          "name": "판교",
+          "pinned": true
         },
         "metadata": {
           "hour": "09:00 ~ 19:00"
@@ -472,7 +477,8 @@ Creates a new cafe.
       "id": "11111111-1111-1111-1111-111111111111",
       "createdAt": "2020-01-01T00:00:00.000Z",
       "updatedAt": "2020-01-01T00:00:00.000Z",
-      "name": "판교"
+      "name": "판교",
+      "pinned": true
     },
     "metadata": {
       "hour": "09:00 ~ 20:00",
@@ -539,7 +545,8 @@ Creates a new cafe.
       "id": "11111111-1111-1111-1111-111111111111",
       "createdAt": "2020-01-01T00:00:00.000Z",
       "updatedAt": "2020-01-01T00:00:00.000Z",
-      "name": "판교"
+      "name": "판교",
+      "pinned": true
     },
     "metadata": {
       "hour": "10:00 ~ 22:00",

--- a/services/http-api/README.md
+++ b/services/http-api/README.md
@@ -897,6 +897,12 @@ Retrieve an entire list of places.
 (empty)
 ```
 
+**Query Parameters**
+
+| **Name** | **Type**  | **Required?**           | **Description**                                                                                                        |
+| -------- | --------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `pinned` | `boolean` | no (default is `false`) | If `pinned` is `true`, then the result will contain only pinned places. Otherwise, the result will contain all places. |
+
 **Response Example**
 
 ```
@@ -908,13 +914,15 @@ Retrieve an entire list of places.
         "id": "11111111-1111-1111-1111-111111111111",
         "createdAt": "2020-01-01T00:00:00.000Z",
         "updatedAt": "2020-01-01T00:00:00.000Z",
-        "name": "판교"
+        "name": "판교",
+        "pinned": true
       },
       {
         "id": "11111111-1111-1111-1111-111111111111",
         "createdAt": "2020-01-01T00:00:00.000Z",
         "updatedAt": "2020-01-01T00:00:00.000Z",
-        "name": "연남동"
+        "name": "연남동",
+        "pinned": false
       }
     ]
   }
@@ -943,6 +951,7 @@ Creates a new place. The `name` should not exist among already existing places.
 ```
 {
   "name": "판교"
+  "pinned": false // optional (default is false)
 }
 ```
 
@@ -954,7 +963,8 @@ Creates a new place. The `name` should not exist among already existing places.
     "id": "11111111-1111-1111-1111-111111111111",
     "createdAt": "2020-01-01T00:00:00.000Z",
     "updatedAt": "2020-01-01T00:00:00.000Z",
-    "name": "판교"
+    "name": "판교",
+    "pinned": false
   }
 }
 ```
@@ -977,7 +987,8 @@ Updates a place. The `name` should not exist among already existing places.
 
 ```
 {
-  "name": "판교"
+  "name": "판교", // optional
+  "pinned": true // optional
 }
 ```
 
@@ -989,7 +1000,8 @@ Updates a place. The `name` should not exist among already existing places.
     "id": "11111111-1111-1111-1111-111111111111",
     "createdAt": "2020-01-01T00:00:00.000Z",
     "updatedAt": "2020-01-01T00:00:00.000Z",
-    "name": "판교"
+    "name": "판교",
+    "pinned": true
   }
 }
 ```

--- a/services/http-api/src/entities/place.ts
+++ b/services/http-api/src/entities/place.ts
@@ -25,16 +25,26 @@ export default class Place {
   @Column({ type: 'varchar', name: 'name', length: 255 })
   name!: string;
 
+  @Column({ type: 'boolean', name: 'pinned' })
+  pinned!: boolean;
+
   public toJsonObject(): AnyJson {
     return {
       id: this.id,
       createdAt: this.createdAt.toISOString(),
       updatedAt: this.updatedAt.toISOString(),
       name: this.name,
+      pinned: this.pinned,
     };
   }
 
-  static readonly columns: string[] = ['id', 'createdAt', 'updatedAt', 'name'];
+  static readonly columns: string[] = [
+    'id',
+    'createdAt',
+    'updatedAt',
+    'name',
+    'pinned',
+  ];
 
   static fromRawColumns(
     raw: Record<string, unknown>,
@@ -51,6 +61,7 @@ export default class Place {
       createdAt: raw[rawColumnName('created_at')],
       updatedAt: raw[rawColumnName('updated_at')],
       name: raw[rawColumnName('name')],
+      pinned: raw[rawColumnName('pinned')],
     } as DeepPartial<Place>);
   }
 }

--- a/services/http-api/src/routes/cafe/index.test.ts
+++ b/services/http-api/src/routes/cafe/index.test.ts
@@ -85,6 +85,7 @@ describe('Cafe - GET /cafe/:cafeId', () => {
           createdAt: place.createdAt.toISOString(),
           updatedAt: place.updatedAt.toISOString(),
           name: '판교',
+          pinned: false,
         },
         metadata: {
           hours: '09:00 ~ 20:00',
@@ -164,6 +165,7 @@ describe('Cafe - GET /cafe/:cafeId', () => {
           createdAt: place.createdAt.toISOString(),
           updatedAt: place.updatedAt.toISOString(),
           name: '성수동',
+          pinned: false,
         },
         metadata: {
           hours: '09:00 ~ 20:00',
@@ -289,6 +291,7 @@ describe('Cafe - GET /cafe/:cafeId', () => {
           createdAt: place.createdAt.toISOString(),
           updatedAt: place.updatedAt.toISOString(),
           name: '성수동',
+          pinned: false,
         },
         metadata: {
           hours: '09:00 ~ 20:00',
@@ -366,6 +369,7 @@ describe('Cafe - GET /cafe/:cafeId', () => {
           createdAt: place.createdAt.toISOString(),
           updatedAt: place.updatedAt.toISOString(),
           name: '성수동',
+          pinned: false,
         },
         metadata: {
           hours: '09:00 ~ 20:00',
@@ -563,6 +567,7 @@ describe('Cafe - PUT /cafe/:cafeId', () => {
       createdAt: newPlace.createdAt.toISOString(),
       updatedAt: newPlace.updatedAt.toISOString(),
       name: '양재',
+      pinned: false,
     });
     expect(metadata).toBe(null);
     expect(state).toBe('active');

--- a/services/http-api/src/routes/place/index.test.ts
+++ b/services/http-api/src/routes/place/index.test.ts
@@ -65,12 +65,41 @@ describe('Place - GET /place/list', () => {
     const {
       place: { count, list },
     } = response.body as {
-      place: { count: number; list: { id: string; name: string }[] };
+      place: {
+        count: number;
+        list: { id: string; name: string; pinned: boolean }[];
+      };
     };
     const names = list.map((item) => item.name);
 
     expect(count).toBe(4);
     expect(names.sort()).toEqual(['판교', '연남동', '양재', '성수동'].sort());
+
+    list.forEach(({ pinned }) => expect(pinned).toBe(false));
+  });
+
+  test('Can retrieve a pinned list of places', async () => {
+    await setupPlace(connection, { name: '판교', pinned: true });
+    await setupPlace(connection, { name: '연남동', pinned: false });
+    await setupPlace(connection, { name: '양재', pinned: true });
+    await setupPlace(connection, { name: '성수동', pinned: false });
+
+    const response = await request
+      .get('/place/list')
+      .query({ pinned: true })
+      .expect(HTTP_OK);
+    const {
+      place: { count, list },
+    } = response.body as {
+      place: {
+        count: number;
+        list: { id: string; name: string; pinned: boolean }[];
+      };
+    };
+    const names = list.map((item) => item.name);
+
+    expect(count).toBe(2);
+    expect(names.sort()).toEqual(['판교', '양재'].sort());
   });
 });
 
@@ -82,14 +111,15 @@ describe('Place - POST /place', () => {
         'x-debug-user-id': uuid.v4(),
         'x-debug-iam-policy': adminerPolicyString,
       })
-      .send({ name: '양재' })
+      .send({ name: '양재', pinned: true })
       .expect(HTTP_CREATED);
 
     const {
-      place: { name },
-    } = response.body as { place: { name: string } };
+      place: { name, pinned },
+    } = response.body as { place: { name: string; pinned: boolean } };
 
     expect(name).toBe('양재');
+    expect(pinned).toBe(true);
   });
 
   test('Requires privilege to create a place', async () => {
@@ -149,6 +179,29 @@ describe('Place - PUT /place/:placeId', () => {
       })
       .send({ name: '성수동' })
       .expect(HTTP_BAD_REQUEST);
+  });
+
+  test('Can pin a place', async () => {
+    const place = await setupPlace(connection, { name: '판교', pinned: false });
+
+    const response = await request
+      .put(`/place/${place.id}`)
+      .set({
+        'x-debug-user-id': uuid.v4(),
+        'x-debug-iam-policy': adminerPolicyString,
+      })
+      .send({ pinned: true })
+      .expect(HTTP_OK);
+
+    const {
+      place: { id, name, pinned },
+    } = response.body as {
+      place: { id: string; name: string; pinned: boolean };
+    };
+
+    expect(id).toBe(place.id);
+    expect(name).toBe('판교');
+    expect(pinned).toBe(true);
   });
 
   test('Throws 404 if place does not exist', async () => {

--- a/services/http-api/src/test/util.ts
+++ b/services/http-api/src/test/util.ts
@@ -7,12 +7,12 @@ import Place from '../entities/place';
 
 export const setupPlace = async (
   connection: Connection,
-  { name }: { name: string }
+  { name, pinned }: { name: string; pinned?: boolean }
 ) => {
   const place = await connection
     .createQueryBuilder(Place, 'place')
     .insert()
-    .values({ name })
+    .values({ name, pinned: pinned ?? false })
     .returning(Place.columns)
     .execute()
     .then((insertResult) =>


### PR DESCRIPTION
fixes #64 

- This updates 3 REST endpoints (`GET /place/list`, `POST /place`, `PUT /place/:placeId`), without deprecation. (The old request signature is still available)