### PR TITLE
Fix type conflict with @types/koa ^2.11.7

### DIFF
--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -26,7 +26,7 @@
     "@tsconfig/recommended": "^1.0.1",
     "@types/jest": "^26.0.19",
     "@types/jsonwebtoken": "^8.5.0",
-    "@types/koa": "^2.11.6",
+    "@types/koa": "^2.13.0",
     "@types/koa-bodyparser": "^4.3.0",
     "@types/koa-logger": "^3.1.1",
     "@types/node": "^14.14.10",

--- a/services/auth/src/entities/policy.ts
+++ b/services/auth/src/entities/policy.ts
@@ -75,9 +75,9 @@ export default class Policy {
   }
 }
 
-export const createPolicyLoader = (context: KoaContextState) =>
+export const createPolicyLoader = (state: KoaContextState) =>
   new DataLoader<string, Policy>(async (policyIds) => {
-    await context.connection();
+    await state.connection();
 
     const normalized = await getManager()
       .createQueryBuilder(Policy, 'policy')

--- a/services/auth/src/entities/user.ts
+++ b/services/auth/src/entities/user.ts
@@ -162,9 +162,9 @@ export default class User {
   }
 }
 
-export const createUserLoader = (context: KoaContextState) =>
+export const createUserLoader = (state: KoaContextState) =>
   new DataLoader<string, User>(async (userIds) => {
-    await context.connection();
+    await state.connection();
 
     const normalized = await getManager()
       .createQueryBuilder(User, 'user')
@@ -175,9 +175,9 @@ export const createUserLoader = (context: KoaContextState) =>
     return userIds.map((id) => normalized[id]);
   });
 
-export const createUserProfileLoader = (context: KoaContextState) =>
+export const createUserProfileLoader = (state: KoaContextState) =>
   new DataLoader<string, UserProfile>(async (userIds) => {
-    await context.connection();
+    await state.connection();
 
     const normalized = await getManager()
       .createQueryBuilder(User, 'user')
@@ -189,9 +189,9 @@ export const createUserProfileLoader = (context: KoaContextState) =>
     return userIds.map((id) => normalized[id]?.profile);
   });
 
-export const createUserPolicyLoader = (context: KoaContextState) =>
+export const createUserPolicyLoader = (state: KoaContextState) =>
   new DataLoader<string, Policy>(async (userIds) => {
-    await context.connection();
+    await state.connection();
 
     const normalized = await getManager()
       .createQueryBuilder(User, 'user')

--- a/services/auth/src/middlewares/db.ts
+++ b/services/auth/src/middlewares/db.ts
@@ -14,11 +14,11 @@ import { KoaContextState } from '../types/koa';
 import { env } from '../util';
 import entities from '../entities';
 
-const createDataLoaders = (context: KoaContextState) => ({
-  user: createUserLoader(context),
-  userProfile: createUserProfileLoader(context),
-  userPolicy: createUserPolicyLoader(context),
-  policy: createPolicyLoader(context),
+const createDataLoaders = (state: KoaContextState) => ({
+  user: createUserLoader(state),
+  userProfile: createUserProfileLoader(state),
+  userPolicy: createUserPolicyLoader(state),
+  policy: createPolicyLoader(state),
 });
 
 export type DataLoaders = ReturnType<typeof createDataLoaders>;

--- a/services/auth/src/routes/auth.control.ts
+++ b/services/auth/src/routes/auth.control.ts
@@ -10,7 +10,7 @@ import User, {
   UserState,
 } from '../entities/user';
 import UserProfile from '../entities/userProfile';
-import { VariablesMap } from '../types/koa';
+import { TransformedVariablesMap } from '../types/koa';
 import Exception, { ExceptionCode } from '../util/error';
 import { generateDefaultUserPolicy } from '../util/iam';
 import { generateToken, TokenSubject } from '../util/token';
@@ -43,7 +43,7 @@ const verifyFirebaseIdToken = async (idToken: string) => {
 };
 
 export const register = handler<
-  VariablesMap,
+  TransformedVariablesMap,
   {
     id_token: string;
   },
@@ -170,7 +170,7 @@ export const register = handler<
 );
 
 export const token = handler<
-  VariablesMap,
+  TransformedVariablesMap,
   {
     id_token: string;
   }
@@ -240,7 +240,7 @@ export const token = handler<
 );
 
 export const me = handler<
-  VariablesMap,
+  TransformedVariablesMap,
   {
     id_token: string;
   }

--- a/services/auth/src/routes/policy/policy.control.ts
+++ b/services/auth/src/routes/policy/policy.control.ts
@@ -4,15 +4,15 @@ import { FOREIGN_KEY_VIOLATION, UNIQUE_VIOLATION } from 'pg-error-constants';
 import { HTTP_CREATED, HTTP_OK } from '../../const';
 import Policy from '../../entities/policy';
 import { SortOrder, SortOrderStrings } from '../../types';
-import { VariablesMap } from '../../types/koa';
+import { TransformedVariablesMap } from '../../types/koa';
 import { enumKeyStrings } from '../../util';
 import Exception, { ExceptionCode } from '../../util/error';
 import { IamPolicy, OperationSchema, OperationType } from '../../util/iam';
 import handler from '../handler';
 
 export const postPolicy = handler<
-  VariablesMap,
-  VariablesMap,
+  TransformedVariablesMap,
+  TransformedVariablesMap,
   {
     name: string;
     value: string;
@@ -145,7 +145,7 @@ enum PolicyListOrder {
 type PolicyListOrderStrings = keyof typeof PolicyListOrder;
 
 export const getPolicyList = handler<
-  VariablesMap,
+  TransformedVariablesMap,
   {
     limit: number;
     cursor?: string;
@@ -258,7 +258,7 @@ export const putPolicy = handler<
   {
     policyId: string;
   },
-  VariablesMap,
+  TransformedVariablesMap,
   {
     name?: string;
     value?: string;

--- a/services/auth/src/routes/policy/policy.control.ts
+++ b/services/auth/src/routes/policy/policy.control.ts
@@ -4,7 +4,10 @@ import { FOREIGN_KEY_VIOLATION, UNIQUE_VIOLATION } from 'pg-error-constants';
 import { HTTP_CREATED, HTTP_OK } from '../../const';
 import Policy from '../../entities/policy';
 import { SortOrder, SortOrderStrings } from '../../types';
-import { TransformedVariablesMap } from '../../types/koa';
+import {
+  TransformedSchemaTypes,
+  TransformedVariablesMap,
+} from '../../types/koa';
 import { enumKeyStrings } from '../../util';
 import Exception, { ExceptionCode } from '../../util/error';
 import { IamPolicy, OperationSchema, OperationType } from '../../util/iam';
@@ -245,6 +248,9 @@ export const getPolicyList = handler<
           order: Joi.string().valid(...enumKeyStrings(SortOrder)),
         })
         .required(),
+    },
+    transform: {
+      query: [{ key: 'limit', type: TransformedSchemaTypes.integer }],
     },
     requiredRules: new OperationSchema({
       operationType: OperationType.query,

--- a/services/auth/src/routes/user/user.control.ts
+++ b/services/auth/src/routes/user/user.control.ts
@@ -7,7 +7,7 @@ import { HTTP_OK } from '../../const';
 import User, { UserState, UserStateStrings } from '../../entities/user';
 import UserProfile from '../../entities/userProfile';
 import { SortOrder, SortOrderStrings } from '../../types';
-import { VariablesMap } from '../../types/koa';
+import { TransformedVariablesMap } from '../../types/koa';
 import { enumKeyStrings } from '../../util';
 import Exception, { ExceptionCode } from '../../util/error';
 import { OperationSchema, OperationType } from '../../util/iam';
@@ -83,7 +83,7 @@ enum UserListOrder {
 type UserListOrderStrings = keyof typeof UserListOrder;
 
 export const getUserList = handler<
-  VariablesMap,
+  TransformedVariablesMap,
   {
     limit: number;
     cursor?: string;
@@ -216,7 +216,7 @@ export const putUserState = handler<
   {
     userId: string;
   },
-  VariablesMap,
+  TransformedVariablesMap,
   {
     state: UserStateStrings;
   }
@@ -310,7 +310,7 @@ export const putUserProfile = handler<
   {
     userId: string;
   },
-  VariablesMap,
+  TransformedVariablesMap,
   {
     name?: string;
     email?: string | null;
@@ -414,7 +414,7 @@ export const putUserPolicy = handler<
   {
     userId: string;
   },
-  VariablesMap,
+  TransformedVariablesMap,
   {
     policyId: string;
   }

--- a/services/auth/src/routes/user/user.control.ts
+++ b/services/auth/src/routes/user/user.control.ts
@@ -7,7 +7,10 @@ import { HTTP_OK } from '../../const';
 import User, { UserState, UserStateStrings } from '../../entities/user';
 import UserProfile from '../../entities/userProfile';
 import { SortOrder, SortOrderStrings } from '../../types';
-import { TransformedVariablesMap } from '../../types/koa';
+import {
+  TransformedSchemaTypes,
+  TransformedVariablesMap,
+} from '../../types/koa';
 import { enumKeyStrings } from '../../util';
 import Exception, { ExceptionCode } from '../../util/error';
 import { OperationSchema, OperationType } from '../../util/iam';
@@ -203,6 +206,9 @@ export const getUserList = handler<
           order: Joi.string().valid(...enumKeyStrings(SortOrder)),
         })
         .required(),
+    },
+    transform: {
+      query: [{ key: 'limit', type: TransformedSchemaTypes.integer }],
     },
     requiredRules: new OperationSchema({
       operationType: OperationType.query,

--- a/services/auth/src/types/koa.ts
+++ b/services/auth/src/types/koa.ts
@@ -21,6 +21,14 @@ export type TransformedVariablesMap = {
   [key: string]: TransformedVariable | TransformedVariable[] | undefined | null;
 };
 
+export enum TransformedSchemaTypes {
+  integer = 'integer',
+  double = 'double',
+  boolean = 'boolean',
+}
+
+export type TransformedFields = { key: string; type: TransformedSchemaTypes }[];
+
 export type TransformedKoaContext<
   ParamsT extends TransformedVariablesMap = TransformedVariablesMap,
   QueryT extends TransformedVariablesMap = TransformedVariablesMap,
@@ -57,6 +65,10 @@ export interface KoaRouteHandlerOptions<
     params?: Schema;
     query?: Schema;
     body?: Schema;
+  };
+  transform?: {
+    params?: TransformedFields;
+    query?: TransformedFields;
   };
   requiredRules?:
     | OperationSchema

--- a/services/auth/src/types/koa.ts
+++ b/services/auth/src/types/koa.ts
@@ -1,11 +1,10 @@
-import Router from '@koa/router';
 import * as Koa from 'koa';
 import { Schema } from 'joi';
 import { Connection } from 'typeorm';
 import app from '../app';
-import { DataLoaders } from '../middlewares/db';
 import { IamPolicy, OperationSchema } from '../util/iam';
 import Logger from '../util/logger';
+import { DataLoaders } from '../middlewares/db';
 
 export interface KoaContextState {
   logger: Logger;
@@ -17,40 +16,41 @@ export interface KoaContextState {
 
 export type VariablesMap = { [key: string]: string };
 
-interface RouteParamContext<
-  ParamsT extends VariablesMap = VariablesMap,
-  QueryT = VariablesMap
-> extends Router.RouterParamContext<KoaContextState, Koa.Context> {
+type TransformedVariable = string | number | boolean;
+export type TransformedVariablesMap = {
+  [key: string]: TransformedVariable | TransformedVariable[] | undefined | null;
+};
+
+export type TransformedKoaContext<
+  ParamsT extends TransformedVariablesMap = TransformedVariablesMap,
+  QueryT extends TransformedVariablesMap = TransformedVariablesMap,
+  BodyT = AnyJson
+> = {
   params: ParamsT;
   query: QueryT;
-}
+  request: {
+    body?: BodyT;
+  };
+  state: KoaContextState;
+  status?: number;
+  body?: AnyJson;
+};
 
-interface KoaTypedRequest<BodyT = AnyJson> extends Koa.Request {
-  body?: BodyT;
-}
+export type KoaRouteHandler = (
+  ctx: Koa.ParameterizedContext<KoaContextState>
+) => Promise<void> | void;
 
-export interface KoaContext<
-  ParamsT extends VariablesMap = VariablesMap,
-  QueryT = VariablesMap,
+export type TransformedKoaRouteHandler<
+  ParamsT extends TransformedVariablesMap = TransformedVariablesMap,
+  QueryT extends TransformedVariablesMap = TransformedVariablesMap,
   BodyT = AnyJson
-> extends Koa.ParameterizedContext<
-    KoaContextState,
-    RouteParamContext<ParamsT, QueryT>
-  > {
-  params: ParamsT;
-  query: QueryT;
-  request: KoaTypedRequest<BodyT>;
-}
-
-export type KoaRouteHandler<
-  ParamsT extends VariablesMap = VariablesMap,
-  QueryT = VariablesMap,
-  BodyT = AnyJson
-> = (ctx: KoaContext<ParamsT, QueryT, BodyT>) => Promise<void> | void;
+> = (
+  ctx: TransformedKoaContext<ParamsT, QueryT, BodyT>
+) => Promise<void> | void;
 
 export interface KoaRouteHandlerOptions<
-  ParamsT extends VariablesMap = VariablesMap,
-  QueryT = VariablesMap,
+  ParamsT extends TransformedVariablesMap = TransformedVariablesMap,
+  QueryT extends TransformedVariablesMap = TransformedVariablesMap,
   BodyT = AnyJson
 > {
   schema?: {
@@ -62,7 +62,7 @@ export interface KoaRouteHandlerOptions<
     | OperationSchema
     | OperationSchema[]
     | ((
-        ctx: KoaContext<ParamsT, QueryT, BodyT>
+        ctx: TransformedKoaContext<ParamsT, QueryT, BodyT>
       ) => OperationSchema | OperationSchema[]);
 }
 

--- a/services/auth/src/util/iam/policy.ts
+++ b/services/auth/src/util/iam/policy.ts
@@ -1,4 +1,3 @@
-import { ParameterizedContext } from 'koa';
 import { IamRule, IamRuleObject, OperationSchema, OperationType } from '.';
 import { KoaContextState } from '../../types/koa';
 import Exception, { ExceptionCode } from '../error';
@@ -25,17 +24,17 @@ export default class IamPolicy {
   }
 
   public canExecuteOperation(
-    ctx: ParameterizedContext<KoaContextState>,
+    state: KoaContextState,
     schema: OperationSchema
   ): boolean {
-    return this.rules.some((rule) => rule.canExecuteOperation(ctx, schema));
+    return this.rules.some((rule) => rule.canExecuteOperation(state, schema));
   }
 
   public canExecuteOperations(
-    ctx: ParameterizedContext<KoaContextState>,
+    state: KoaContextState,
     schemas: OperationSchema[]
   ): boolean {
-    return schemas.every((schema) => this.canExecuteOperation(ctx, schema));
+    return schemas.every((schema) => this.canExecuteOperation(state, schema));
   }
 
   static isValidPolicyJsonObject(json: AnyJson): json is IamPolicyObject {

--- a/services/auth/src/util/iam/rule.ts
+++ b/services/auth/src/util/iam/rule.ts
@@ -1,4 +1,3 @@
-import { ParameterizedContext } from 'koa';
 import {
   isOperationTypeString,
   OperationSchema,
@@ -69,14 +68,14 @@ export default class IamRule {
   }
 
   public canExecuteOperation(
-    ctx: ParameterizedContext<KoaContextState>,
+    state: KoaContextState,
     schema: OperationSchema
   ): boolean {
     return (
       this.operationType === schema.operationType &&
       this.compareOperation(this.operation, schema.operation) &&
       (this.resource === ANY_WORD ||
-        (this.resource === MATCH_UID && schema.resource === ctx.state.uid) ||
+        (this.resource === MATCH_UID && schema.resource === state.uid) ||
         this.resource === schema.resource)
     );
   }

--- a/services/http-api/package.json
+++ b/services/http-api/package.json
@@ -32,7 +32,7 @@
     "@types/jest": "^26.0.19",
     "@types/joi": "^14.3.4",
     "@types/jsonwebtoken": "^8.5.0",
-    "@types/koa": "2.11.7",
+    "@types/koa": "^2.13.0",
     "@types/koa-bodyparser": "^4.3.0",
     "@types/koa-logger": "^3.1.1",
     "@types/koa__cors": "^3.0.2",

--- a/services/http-api/src/entities/cafe.ts
+++ b/services/http-api/src/entities/cafe.ts
@@ -1,7 +1,6 @@
 import '../util/extension';
 
 import DataLoader from 'dataloader';
-import { ParameterizedContext } from 'koa';
 import {
   Column,
   Connection,
@@ -159,12 +158,12 @@ export default class Cafe {
 }
 
 export const createCafeLoader = (
-  ctx: ParameterizedContext<KoaContextState>,
+  state: KoaContextState,
   options?: { manager?: EntityManager }
 ) =>
   new DataLoader<string, Cafe>(async (cafeIds) => {
     const manager =
-      options?.manager ?? (await ctx.state.connection()).createEntityManager();
+      options?.manager ?? (await state.connection()).createEntityManager();
 
     const normalized = await manager
       .createQueryBuilder(Cafe, 'cafe')
@@ -181,15 +180,15 @@ export const createCafeLoader = (
   });
 
 export const createCafeWithImagesLoader = (
-  ctx: ParameterizedContext<KoaContextState>,
+  state: KoaContextState,
   options?: { manager?: EntityManager; showHiddenImages?: boolean }
 ) =>
   new DataLoader<string, Cafe>(async (cafeIds) => {
     if (options?.showHiddenImages ?? false) {
       if (
         !(
-          ctx.state.policy?.canExecuteOperations(
-            ctx,
+          state.policy?.canExecuteOperations(
+            state,
             cafeIds.map(
               (cafeId) =>
                 new OperationSchema({
@@ -206,7 +205,7 @@ export const createCafeWithImagesLoader = (
     }
 
     const manager =
-      options?.manager ?? (await ctx.state.connection()).createEntityManager();
+      options?.manager ?? (await state.connection()).createEntityManager();
 
     let query = manager
       .createQueryBuilder(Cafe, 'cafe')

--- a/services/http-api/src/middlewares/db.ts
+++ b/services/http-api/src/middlewares/db.ts
@@ -9,16 +9,16 @@ import entities from '../entities';
 import { env } from '../util';
 import { createCafeLoader, createCafeWithImagesLoader } from '../entities/cafe';
 
-const createDataLoaders = (ctx: ParameterizedContext<KoaContextState>) => {
-  const cafeWithAllImages = createCafeWithImagesLoader(ctx, {
+const createDataLoaders = (state: KoaContextState) => {
+  const cafeWithAllImages = createCafeWithImagesLoader(state, {
     showHiddenImages: true,
   });
-  const cafeWithActiveImages = createCafeWithImagesLoader(ctx, {
+  const cafeWithActiveImages = createCafeWithImagesLoader(state, {
     showHiddenImages: false,
   });
 
   return {
-    cafe: createCafeLoader(ctx),
+    cafe: createCafeLoader(state),
     cafeWithImages: (options: { showHiddenImages: boolean }) =>
       options.showHiddenImages ? cafeWithAllImages : cafeWithActiveImages,
   };
@@ -64,7 +64,7 @@ const db = (): Middleware<KoaContextState> => {
       return connection;
     };
 
-    ctx.state.loaders = createDataLoaders(ctx);
+    ctx.state.loaders = createDataLoaders(ctx.state);
 
     await next();
   };

--- a/services/http-api/src/routes/cafe/cafe.control.ts
+++ b/services/http-api/src/routes/cafe/cafe.control.ts
@@ -13,7 +13,7 @@ import CafeImageCount from '../../entities/cafeImageCount';
 import CafeStatistic from '../../entities/cafeStatistic';
 import Place from '../../entities/place';
 import { SortOrder, SortOrderStrings } from '../../types';
-import { VariablesMap } from '../../types/koa';
+import { TransformedVariablesMap } from '../../types/koa';
 import { enumKeyStrings } from '../../util';
 import Exception, { ExceptionCode } from '../../util/error';
 import { OperationSchema, OperationType } from '../../util/iam';
@@ -47,7 +47,7 @@ export const getOne = handler<
       if (
         !(
           ctx.state.policy?.canExecuteOperation(
-            ctx,
+            ctx.state,
             new OperationSchema({
               operationType: OperationType.query,
               operation: 'api.cafe.hidden',
@@ -77,7 +77,7 @@ export const getOne = handler<
 );
 
 export const getFeed = handler<
-  VariablesMap,
+  TransformedVariablesMap,
   {
     limit: number;
     cursor?: string;
@@ -205,7 +205,7 @@ export const getFeed = handler<
 );
 
 export const getCount = handler<
-  VariablesMap,
+  TransformedVariablesMap,
   {
     keyword?: string;
     showHidden?: boolean;
@@ -273,7 +273,7 @@ enum CafeListOrder {
 type CafeListOrderStrings = keyof typeof CafeListOrder;
 
 export const getList = handler<
-  VariablesMap,
+  TransformedVariablesMap,
   {
     limit: number;
     cursor?: string;
@@ -513,8 +513,8 @@ export const getList = handler<
 );
 
 export const create = handler<
-  VariablesMap,
-  VariablesMap,
+  TransformedVariablesMap,
+  TransformedVariablesMap,
   {
     name: string;
     placeId: string;
@@ -584,7 +584,7 @@ export const create = handler<
         })
         .execute();
 
-      return createCafeWithImagesLoader(ctx, { manager }).load(cafe.id);
+      return createCafeWithImagesLoader(ctx.state, { manager }).load(cafe.id);
     });
 
     ctx.status = HTTP_CREATED;
@@ -670,7 +670,7 @@ export const updateOne = handler<
           throw e;
         });
 
-      return createCafeWithImagesLoader(ctx, {
+      return createCafeWithImagesLoader(ctx.state, {
         manager,
         showHiddenImages,
       }).load(updated.id);

--- a/services/http-api/src/routes/cafe/cafe.control.ts
+++ b/services/http-api/src/routes/cafe/cafe.control.ts
@@ -13,7 +13,10 @@ import CafeImageCount from '../../entities/cafeImageCount';
 import CafeStatistic from '../../entities/cafeStatistic';
 import Place from '../../entities/place';
 import { SortOrder, SortOrderStrings } from '../../types';
-import { TransformedVariablesMap } from '../../types/koa';
+import {
+  TransformedSchemaTypes,
+  TransformedVariablesMap,
+} from '../../types/koa';
 import { enumKeyStrings } from '../../util';
 import Exception, { ExceptionCode } from '../../util/error';
 import { OperationSchema, OperationType } from '../../util/iam';
@@ -72,6 +75,11 @@ export const getOne = handler<
         .keys({ cafeId: joi.string().uuid({ version: 'uuidv4' }).required() })
         .required(),
       query: joi.object().keys({ showHiddenImages: joi.boolean() }),
+    },
+    transform: {
+      query: [
+        { key: 'showHiddenImages', type: TransformedSchemaTypes.boolean },
+      ],
     },
   }
 );
@@ -201,6 +209,9 @@ export const getFeed = handler<
         .oxor('placeId', 'placeName')
         .required(),
     },
+    transform: {
+      query: [{ key: 'limit', type: TransformedSchemaTypes.integer }],
+    },
   }
 );
 
@@ -247,6 +258,9 @@ export const getCount = handler<
         keyword: joi.string().min(1).max(255),
         showHidden: joi.boolean(),
       }),
+    },
+    transform: {
+      query: [{ key: 'showHidden', type: TransformedSchemaTypes.boolean }],
     },
     requiredRules: (ctx) => [
       ...(ctx.query.showHidden ?? false
@@ -489,6 +503,13 @@ export const getList = handler<
         })
         .required(),
     },
+    transform: {
+      query: [
+        { key: 'limit', type: TransformedSchemaTypes.integer },
+        { key: 'showHidden', type: TransformedSchemaTypes.boolean },
+        { key: 'showHiddenImages', type: TransformedSchemaTypes.boolean },
+      ],
+    },
     requiredRules: (ctx) => [
       ...(ctx.query.showHidden ?? false
         ? [
@@ -701,6 +722,11 @@ export const updateOne = handler<
         })
         .or('name', 'placeId', 'metadata', 'state')
         .required(),
+    },
+    transform: {
+      query: [
+        { key: 'showHiddenImages', type: TransformedSchemaTypes.boolean },
+      ],
     },
     requiredRules: (ctx) =>
       new OperationSchema({

--- a/services/http-api/src/routes/cafe/image/cafeImage.control.ts
+++ b/services/http-api/src/routes/cafe/image/cafeImage.control.ts
@@ -7,7 +7,7 @@ import CafeImage, {
   CafeImageStateStrings,
 } from '../../../entities/cafeImage';
 import CafeImageCount from '../../../entities/cafeImageCount';
-import { VariablesMap } from '../../../types/koa';
+import { TransformedVariablesMap } from '../../../types/koa';
 import { enumKeyStrings } from '../../../util';
 import Exception, { ExceptionCode } from '../../../util/error';
 import { OperationSchema, OperationType } from '../../../util/iam';
@@ -15,7 +15,7 @@ import handler from '../../handler';
 
 export const create = handler<
   { cafeId: string },
-  VariablesMap,
+  TransformedVariablesMap,
   {
     uri: string;
     metadata?: AnyJson;
@@ -187,7 +187,7 @@ export const updateList = handler<
   {
     cafeId: string;
   },
-  VariablesMap,
+  TransformedVariablesMap,
   {
     list: {
       id: string;
@@ -299,7 +299,7 @@ export const updateOne = handler<
     cafeId: string;
     cafeImageId: string;
   },
-  VariablesMap,
+  TransformedVariablesMap,
   {
     uri?: string;
     metadata?: AnyJson | null;
@@ -440,7 +440,7 @@ export const deleteList = handler<
   {
     cafeId: string;
   },
-  VariablesMap,
+  TransformedVariablesMap,
   {
     list: string[];
   }

--- a/services/http-api/src/routes/cafe/index.test.ts
+++ b/services/http-api/src/routes/cafe/index.test.ts
@@ -489,6 +489,7 @@ describe('Cafe - GET /cafe/:cafeId', () => {
           createdAt: place.createdAt.toISOString(),
           updatedAt: place.updatedAt.toISOString(),
           name: '성수동',
+          pinned: false,
         },
         metadata: {
           hours: '09:00 ~ 20:00',

--- a/services/http-api/src/routes/cafe/list.test.ts
+++ b/services/http-api/src/routes/cafe/list.test.ts
@@ -410,6 +410,19 @@ describe('Cafe - GET /cafe/count', () => {
 
     expect(count).toBe(NUM_TEST_CAFES);
   });
+
+  test('Can interpret query parameter: showHidden=false as it is', async () => {
+    const response = await request
+      .get('/cafe/count')
+      .query({ showHidden: false })
+      .expect(HTTP_OK);
+
+    const {
+      cafe: { count },
+    } = response.body as { cafe: { count: number } };
+
+    expect(count).toBe(activeCafeIds.length);
+  });
 });
 
 describe('Cafe - GET /cafe/list', () => {

--- a/services/http-api/src/routes/event/event.control.ts
+++ b/services/http-api/src/routes/event/event.control.ts
@@ -2,14 +2,14 @@ import joi from 'joi';
 import { getRepository } from 'typeorm';
 import { HTTP_OK } from '../../const';
 import Event, { EventCategory, EventName } from '../../entities/event';
-import { VariablesMap } from '../../types/koa';
+import { TransformedVariablesMap } from '../../types/koa';
 import { enumKeyStrings } from '../../util';
 import Exception, { ExceptionCode } from '../../util/error';
 import handler from '../handler';
 
 export const create = handler<
-  VariablesMap,
-  VariablesMap,
+  TransformedVariablesMap,
+  TransformedVariablesMap,
   {
     category: EventCategory;
     name: EventName;

--- a/services/http-api/src/routes/handler.ts
+++ b/services/http-api/src/routes/handler.ts
@@ -1,23 +1,26 @@
+import { Schema } from 'joi';
+import { HTTP_INTERNAL_SERVER_ERROR } from '../const';
 import {
-  KoaContext,
   KoaRouteHandler,
   KoaRouteHandlerOptions,
-  VariablesMap,
+  TransformedKoaContext,
+  TransformedVariablesMap,
+  TransformedKoaRouteHandler,
 } from '../types/koa';
 import Exception, { ExceptionCode } from '../util/error';
 import { OperationSchema } from '../util/iam';
 
 const normalizeRequiredRules = <
-  ParamsT extends VariablesMap = VariablesMap,
-  QueryT = VariablesMap,
+  ParamsT extends TransformedVariablesMap = TransformedVariablesMap,
+  QueryT extends TransformedVariablesMap = TransformedVariablesMap,
   BodyT = AnyJson
 >(
-  ctx: KoaContext<ParamsT, QueryT, BodyT>,
+  ctx: TransformedKoaContext<ParamsT, QueryT, BodyT>,
   rules?:
     | OperationSchema
     | OperationSchema[]
     | ((
-        ctx: KoaContext<ParamsT, QueryT, BodyT>
+        ctx: TransformedKoaContext<ParamsT, QueryT, BodyT>
       ) => OperationSchema | OperationSchema[])
 ) => {
   if (!rules) {
@@ -32,53 +35,90 @@ const normalizeRequiredRules = <
   return Array.isArray(rules) ? rules : [rules];
 };
 
+class SchemaValidator<T> {
+  raw: unknown;
+
+  schema: Schema | undefined;
+
+  private transformed: T | undefined;
+
+  constructor(raw: unknown, schema?: Schema) {
+    this.raw = raw;
+    this.schema = schema;
+  }
+
+  validate(options?: { errorMessage: string }): SchemaValidator<T> {
+    const { error } = this.schema?.validate(this.raw) || {};
+    if (error) {
+      throw new Exception(ExceptionCode.badRequest, {
+        message: options?.errorMessage,
+        details: error,
+      });
+    }
+    return this;
+  }
+
+  transform(): SchemaValidator<T> {
+    this.transformed = this.raw as T;
+
+    return this;
+  }
+
+  getVariables(options?: { strict: boolean }): T {
+    if (options?.strict) {
+      if (!this.transformed) {
+        throw new Error(
+          'Cannot access getter "variables" prior of calling "transform()"'
+        );
+      }
+
+      return this.transformed;
+    }
+
+    return this.transformed ?? (this.raw as T);
+  }
+}
+
 const handler = <
-  ParamsT extends VariablesMap = VariablesMap,
-  QueryT = VariablesMap,
+  ParamsT extends TransformedVariablesMap = TransformedVariablesMap,
+  QueryT extends TransformedVariablesMap = TransformedVariablesMap,
   BodyT = AnyJson
 >(
-  routeHandler: KoaRouteHandler<ParamsT, QueryT, BodyT>,
+  routeHandler: TransformedKoaRouteHandler<ParamsT, QueryT, BodyT>,
   options?: KoaRouteHandlerOptions<ParamsT, QueryT, BodyT>
-): KoaRouteHandler<Record<string, string>, QueryT, BodyT> => async (ctx) => {
-  if (options?.schema?.params) {
-    const validation = options.schema.params.validate(ctx.params);
-    if (validation.error) {
-      throw new Exception(ExceptionCode.badRequest, {
-        message: 'request params validation failed',
-        details: validation.error,
-      });
-    }
-  }
-
-  if (options?.schema?.query) {
-    const validation = options.schema.query.validate(ctx.query);
-    if (validation.error) {
-      throw new Exception(ExceptionCode.badRequest, {
-        message: 'request query validation failed',
-        details: validation.error,
-      });
-    }
-  }
-
-  if (options?.schema?.body) {
-    const validation = options.schema.body.validate(ctx.request.body);
-    if (validation.error) {
-      throw new Exception(ExceptionCode.badRequest, {
-        message: 'request body validation failed',
-        details: validation.error,
-      });
-    }
-  }
+): KoaRouteHandler => async (ctx) => {
+  const context: TransformedKoaContext<ParamsT, QueryT, BodyT> = {
+    params: new SchemaValidator<ParamsT>(ctx.params, options?.schema?.params)
+      .validate({
+        errorMessage: 'request params validation failed',
+      })
+      .transform()
+      .getVariables({ strict: true }),
+    query: new SchemaValidator<QueryT>(ctx.query, options?.schema?.query)
+      .validate({
+        errorMessage: 'request query validation failed',
+      })
+      .transform()
+      .getVariables({ strict: true }),
+    request: {
+      body: new SchemaValidator<BodyT>(ctx.request.body, options?.schema?.body)
+        .validate({
+          errorMessage: 'request body validation failed',
+        })
+        .getVariables(),
+    },
+    state: ctx.state,
+  };
 
   const requiredRules = normalizeRequiredRules<ParamsT, QueryT, BodyT>(
-    ctx as KoaContext<ParamsT, QueryT, BodyT>,
+    context,
     options?.requiredRules
   );
 
   if (
     requiredRules &&
     requiredRules.length > 0 &&
-    !ctx.state.policy?.canExecuteOperations(ctx, requiredRules)
+    !ctx.state.policy?.canExecuteOperations(ctx.state, requiredRules)
   ) {
     throw new Exception(ExceptionCode.forbidden, {
       message: 'request context does not have privilege to execute operation',
@@ -86,7 +126,10 @@ const handler = <
     });
   }
 
-  await routeHandler(ctx as KoaContext<ParamsT, QueryT, BodyT>);
+  await routeHandler(context);
+
+  ctx.status = context.status ?? HTTP_INTERNAL_SERVER_ERROR;
+  ctx.body = context.body;
 };
 
 export default handler;

--- a/services/http-api/src/routes/place/place.control.ts
+++ b/services/http-api/src/routes/place/place.control.ts
@@ -3,12 +3,15 @@ import { FOREIGN_KEY_VIOLATION, UNIQUE_VIOLATION } from 'pg-error-constants';
 import { getRepository } from 'typeorm';
 import { HTTP_CREATED, HTTP_OK } from '../../const';
 import Place from '../../entities/place';
-import { TransformedVariablesMap } from '../../types/koa';
+import {
+  TransformedSchemaTypes,
+  TransformedVariablesMap,
+} from '../../types/koa';
 import Exception, { ExceptionCode } from '../../util/error';
 import { OperationSchema, OperationType } from '../../util/iam';
 import handler from '../handler';
 
-export const getList = handler<VariablesMap, { pinned?: boolean }>(
+export const getList = handler<TransformedVariablesMap, { pinned?: boolean }>(
   async (ctx) => {
     const { pinned = false } = ctx.query;
 
@@ -39,13 +42,16 @@ export const getList = handler<VariablesMap, { pinned?: boolean }>(
         })
         .required(),
     },
+    transform: {
+      query: [{ key: 'pinned', type: TransformedSchemaTypes.boolean }],
+    },
   }
 );
 
 export const create = handler<
   TransformedVariablesMap,
   TransformedVariablesMap,
-  { name: string, pinned?: boolean }
+  { name: string; pinned?: boolean }
 >(
   async (ctx) => {
     if (!ctx.request.body) {
@@ -101,7 +107,7 @@ export const create = handler<
 export const updateOne = handler<
   { placeId: string },
   TransformedVariablesMap,
-  { name?: string; pinned?: boolean; }
+  { name?: string; pinned?: boolean }
 >(
   async (ctx) => {
     if (!ctx.request.body) {

--- a/services/http-api/src/routes/place/place.control.ts
+++ b/services/http-api/src/routes/place/place.control.ts
@@ -3,7 +3,7 @@ import { FOREIGN_KEY_VIOLATION, UNIQUE_VIOLATION } from 'pg-error-constants';
 import { getRepository } from 'typeorm';
 import { HTTP_CREATED, HTTP_OK } from '../../const';
 import Place from '../../entities/place';
-import { VariablesMap } from '../../types/koa';
+import { TransformedVariablesMap } from '../../types/koa';
 import Exception, { ExceptionCode } from '../../util/error';
 import { OperationSchema, OperationType } from '../../util/iam';
 import handler from '../handler';
@@ -43,9 +43,9 @@ export const getList = handler<VariablesMap, { pinned?: boolean }>(
 );
 
 export const create = handler<
-  VariablesMap,
-  VariablesMap,
-  { name: string; pinned?: boolean }
+  TransformedVariablesMap,
+  TransformedVariablesMap,
+  { name: string, pinned?: boolean }
 >(
   async (ctx) => {
     if (!ctx.request.body) {
@@ -100,8 +100,8 @@ export const create = handler<
 
 export const updateOne = handler<
   { placeId: string },
-  VariablesMap,
-  { name?: string; pinned?: boolean }
+  TransformedVariablesMap,
+  { name?: string; pinned?: boolean; }
 >(
   async (ctx) => {
     if (!ctx.request.body) {
@@ -168,8 +168,8 @@ export const updateOne = handler<
 );
 
 export const deleteList = handler<
-  VariablesMap,
-  VariablesMap,
+  TransformedVariablesMap,
+  TransformedVariablesMap,
   {
     list: string[];
   }

--- a/services/http-api/src/types/koa.ts
+++ b/services/http-api/src/types/koa.ts
@@ -21,6 +21,14 @@ export type TransformedVariablesMap = {
   [key: string]: TransformedVariable | TransformedVariable[] | undefined | null;
 };
 
+export enum TransformedSchemaTypes {
+  integer = 'integer',
+  double = 'double',
+  boolean = 'boolean',
+}
+
+export type TransformedFields = { key: string; type: TransformedSchemaTypes }[];
+
 export type TransformedKoaContext<
   ParamsT extends TransformedVariablesMap = TransformedVariablesMap,
   QueryT extends TransformedVariablesMap = TransformedVariablesMap,
@@ -57,6 +65,10 @@ export interface KoaRouteHandlerOptions<
     params?: Schema;
     query?: Schema;
     body?: Schema;
+  };
+  transform?: {
+    params?: TransformedFields;
+    query?: TransformedFields;
   };
   requiredRules?:
     | OperationSchema

--- a/services/http-api/src/types/koa.ts
+++ b/services/http-api/src/types/koa.ts
@@ -1,4 +1,3 @@
-import Router from '@koa/router';
 import * as Koa from 'koa';
 import { Schema } from 'joi';
 import { Connection } from 'typeorm';
@@ -17,40 +16,41 @@ export interface KoaContextState {
 
 export type VariablesMap = { [key: string]: string };
 
-interface RouteParamContext<
-  ParamsT extends VariablesMap = VariablesMap,
-  QueryT = VariablesMap
-> extends Router.RouterParamContext<KoaContextState, Koa.Context> {
+type TransformedVariable = string | number | boolean;
+export type TransformedVariablesMap = {
+  [key: string]: TransformedVariable | TransformedVariable[] | undefined | null;
+};
+
+export type TransformedKoaContext<
+  ParamsT extends TransformedVariablesMap = TransformedVariablesMap,
+  QueryT extends TransformedVariablesMap = TransformedVariablesMap,
+  BodyT = AnyJson
+> = {
   params: ParamsT;
   query: QueryT;
-}
+  request: {
+    body?: BodyT;
+  };
+  state: KoaContextState;
+  status?: number;
+  body?: AnyJson;
+};
 
-interface KoaTypedRequest<BodyT = AnyJson> extends Koa.Request {
-  body?: BodyT;
-}
+export type KoaRouteHandler = (
+  ctx: Koa.ParameterizedContext<KoaContextState>
+) => Promise<void> | void;
 
-export interface KoaContext<
-  ParamsT extends VariablesMap = VariablesMap,
-  QueryT = VariablesMap,
+export type TransformedKoaRouteHandler<
+  ParamsT extends TransformedVariablesMap = TransformedVariablesMap,
+  QueryT extends TransformedVariablesMap = TransformedVariablesMap,
   BodyT = AnyJson
-> extends Koa.ParameterizedContext<
-    KoaContextState,
-    RouteParamContext<ParamsT, QueryT>
-  > {
-  params: ParamsT;
-  query: QueryT;
-  request: KoaTypedRequest<BodyT>;
-}
-
-export type KoaRouteHandler<
-  ParamsT extends VariablesMap = VariablesMap,
-  QueryT = VariablesMap,
-  BodyT = AnyJson
-> = (ctx: KoaContext<ParamsT, QueryT, BodyT>) => Promise<void> | void;
+> = (
+  ctx: TransformedKoaContext<ParamsT, QueryT, BodyT>
+) => Promise<void> | void;
 
 export interface KoaRouteHandlerOptions<
-  ParamsT extends VariablesMap = VariablesMap,
-  QueryT = VariablesMap,
+  ParamsT extends TransformedVariablesMap = TransformedVariablesMap,
+  QueryT extends TransformedVariablesMap = TransformedVariablesMap,
   BodyT = AnyJson
 > {
   schema?: {
@@ -62,7 +62,7 @@ export interface KoaRouteHandlerOptions<
     | OperationSchema
     | OperationSchema[]
     | ((
-        ctx: KoaContext<ParamsT, QueryT, BodyT>
+        ctx: TransformedKoaContext<ParamsT, QueryT, BodyT>
       ) => OperationSchema | OperationSchema[]);
 }
 

--- a/services/http-api/src/util/iam/policy.ts
+++ b/services/http-api/src/util/iam/policy.ts
@@ -1,4 +1,3 @@
-import { ParameterizedContext } from 'koa';
 import { IamRule, IamRuleObject, OperationSchema, OperationType } from '.';
 import { KoaContextState } from '../../types/koa';
 import Exception, { ExceptionCode } from '../error';
@@ -25,17 +24,17 @@ export default class IamPolicy {
   }
 
   public canExecuteOperation(
-    ctx: ParameterizedContext<KoaContextState>,
+    state: KoaContextState,
     schema: OperationSchema
   ): boolean {
-    return this.rules.some((rule) => rule.canExecuteOperation(ctx, schema));
+    return this.rules.some((rule) => rule.canExecuteOperation(state, schema));
   }
 
   public canExecuteOperations(
-    ctx: ParameterizedContext<KoaContextState>,
+    state: KoaContextState,
     schemas: OperationSchema[]
   ): boolean {
-    return schemas.every((schema) => this.canExecuteOperation(ctx, schema));
+    return schemas.every((schema) => this.canExecuteOperation(state, schema));
   }
 
   static isValidPolicyJsonObject(json: AnyJson): json is IamPolicyObject {

--- a/services/http-api/src/util/iam/rule.ts
+++ b/services/http-api/src/util/iam/rule.ts
@@ -1,4 +1,3 @@
-import { ParameterizedContext } from 'koa';
 import {
   isOperationTypeString,
   OperationSchema,
@@ -69,14 +68,14 @@ export default class IamRule {
   }
 
   public canExecuteOperation(
-    ctx: ParameterizedContext<KoaContextState>,
+    state: KoaContextState,
     schema: OperationSchema
   ): boolean {
     return (
       this.operationType === schema.operationType &&
       this.compareOperation(this.operation, schema.operation) &&
       (this.resource === ANY_WORD ||
-        (this.resource === MATCH_UID && schema.resource === ctx.state.uid) ||
+        (this.resource === MATCH_UID && schema.resource === state.uid) ||
         this.resource === schema.resource)
     );
   }


### PR DESCRIPTION
- Koa context 관련 type을 업데이트하여, `@types/koa`와 conflict이 없도록 수정
- URL parameter와 query parameter를 이제 type에 따라 올바르게 파싱하도록 수정
  - 이전에는 type과 관련없이, 런타임에는 string으로 취급되고 있었음
  - 현재는 number (integer, double), boolean type에 대해 파싱 구현됨
  - 관련 TC 2개 추가