### PR TITLE
 feat: 메인화면 장소 추가를 위한 코드 수정

### DIFF
--- a/app/src/components/others/PlaceSlide/index.css
+++ b/app/src/components/others/PlaceSlide/index.css
@@ -1,9 +1,14 @@
 .place-container {
     width: 100%;
     overflow-x: auto;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    align-content: flex-start;
 }
 .place-wrapper {
-	flex: 1;
+    min-width: 20%;
 	text-align: center;
 }
 .place-wrapper span {

--- a/app/src/components/pages/Intro/index.css
+++ b/app/src/components/pages/Intro/index.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap');
 .cafe-preview-info {
     padding-left: 20px;
 }
@@ -24,6 +23,8 @@
     color: #03c75a;
 }
 .web-instagram {
+    font-size: 15px;
+    line-height: 0.2em;
     font-family: 'Roboto Mono', monospace;
     color: #D94854;
 }

--- a/app/src/components/pages/Intro/index.css
+++ b/app/src/components/pages/Intro/index.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap');
 .cafe-preview-info {
     padding-left: 20px;
 }
@@ -17,5 +18,12 @@
     flex: 1;
     text-align: center;
     font-size: 12px;
-    padding: 12px 0px;
+    padding-bottom: 12px;
+}
+.web-naver {
+    color: #03c75a;
+}
+.web-instagram {
+    font-family: 'Roboto Mono', monospace;
+    color: #D94854;
 }

--- a/app/src/components/pages/Intro/index.tsx
+++ b/app/src/components/pages/Intro/index.tsx
@@ -49,8 +49,8 @@ const Intro = () => {
                         </div>
                         <CafeByPlace cafes={cafes} setCurrentCafeIndex={setCurrentCafeIndex}/>
                         <StyledRowFlex className="cafe-preview-websearch">
-                            <span onClick={() => openSearch((cafes[currentCafeIndex]?.name)+" "+cafes[currentCafeIndex].place.name, "Naver")}>네이버 바로가기</span>
-                            <span onClick={() => openSearch((cafes[currentCafeIndex]?.name), "Instagram")}>인스타그램 바로가기</span>       
+                            <span onClick={() => openSearch((cafes[currentCafeIndex]?.name)+" "+cafes[currentCafeIndex].place.name, "Naver")}><b className="web-naver">N</b> 네이버 바로가기</span>
+                            <span onClick={() => openSearch((cafes[currentCafeIndex]?.name), "Instagram")}><b className="web-instagram">I</b> 인스타그램 바로가기</span>       
                         </StyledRowFlex>
                     </div>
                     <PlaceSlide places={places} currentPlaceIndex={currentPlaceIndex} setCurrentPlaceIndex={setCurrentPlaceIndex}/>


### PR DESCRIPTION
#76 PR이 rebase 했더니 과거 커밋이 포함되어 다시 생성합니다 ㅜ;

### Changes
- 메인화면 하단 장소 표시 코드 수정
변경 전 : 1 row에 장소마다 `flex:1` 으로 나눠서 사용
변경 후 : 1 row 최대 5개의 장소

- 메인화면 `네이버 바로가기`, `인스타 바로가기` 디자인 업데이트

- 스크린샷
<img width="378" alt="Screen Shot 2021-03-09 at 8 22 52 PM" src="https://user-images.githubusercontent.com/40883884/110463446-43663480-8115-11eb-8443-b8d7280fe047.png">