### PR TITLE
Use redux to control navigation states, places, and cafes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,14 +3,17 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.5.0",
     "react": "^17.0.1",
     "react-copy-to-clipboard": "^5.0.2",
     "react-device-detect": "^1.14.0",
     "react-dom": "^17.0.1",
+    "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
     "react-spring": "^8.0.27",
     "react-swipeable": "^6.0.1",
+    "redux": "^4.0.5",
     "styled-components": "^5.2.1",
     "typescript": "4.0.5",
     "web-vitals": "^0.2.4"
@@ -24,6 +27,7 @@
     "@types/react": "^16.9.56",
     "@types/react-copy-to-clipboard": "^4.3.0",
     "@types/react-dom": "^16.9.8",
+    "@types/react-redux": "^7.1.16",
     "@types/react-router-dom": "^5.1.6",
     "@types/styled-components": "^5.1.4"
   },

--- a/app/src/components/others/CafeByPlace/index.tsx
+++ b/app/src/components/others/CafeByPlace/index.tsx
@@ -1,31 +1,27 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { TypeCafe } from '../../../utils/type';
 import { StyledCarouselImage } from '../../../utils/styled';
 import CarouselMainImage from '../../others/CarouselMainImage';
 import CarouselHorizontal from '../../others/CarouselHorizontal';
+import { useAppDispatch } from '../../../store/hooks';
+import introNavSlice from '../../../store/modules/intro-nav';
 
 type CafeByPlaceProps = {
     cafes: TypeCafe[];
-    setCurrentCafeIndex: (index: number) => void;
     isImageReady: boolean;
     setIsImageReady: (isImageReady: boolean) => void;
 }
 
-const CafeByPlace = ({cafes, setCurrentCafeIndex, isImageReady, setIsImageReady}: CafeByPlaceProps) => {
-    const ref = useRef<number>(0);
-
-    useEffect(() => {
-        if(cafes.length === 1){
-            setCurrentCafeIndex(0);
-        }
-    }, [cafes.length, setCurrentCafeIndex])
+const CafeByPlace = ({cafes, isImageReady, setIsImageReady}: CafeByPlaceProps) => {
+    const dispatch = useAppDispatch();
+    const setCurrentCafeIndex = (index: number) => dispatch(introNavSlice.actions.navigateToCafe(index));
 
     if(cafes.length === 1){
         return  <CarouselMainImage cafe={cafes[0]} isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
     }
 
     return(
-        <CarouselHorizontal title="Carousel" setCurrentIndex={setCurrentCafeIndex} ref={ref}>
+        <CarouselHorizontal title="Carousel" setCurrentIndex={setCurrentCafeIndex}>
         {cafes?.map((cafe) => {
             return(
                 <StyledCarouselImage key={cafe.id}>

--- a/app/src/components/others/CafeByPlace/index.tsx
+++ b/app/src/components/others/CafeByPlace/index.tsx
@@ -1,28 +1,34 @@
 import React from 'react';
-import { TypeCafe } from '../../../utils/type';
 import { StyledCarouselImage } from '../../../utils/styled';
 import CarouselMainImage from '../../others/CarouselMainImage';
 import CarouselHorizontal from '../../others/CarouselHorizontal';
-import { useAppDispatch } from '../../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import introNavSlice from '../../../store/modules/intro-nav';
+import { currentIntroCafeListSelector } from '../../../store/selectors/cafe';
 
 type CafeByPlaceProps = {
-    cafes: TypeCafe[];
     isImageReady: boolean;
     setIsImageReady: (isImageReady: boolean) => void;
 }
 
-const CafeByPlace = ({cafes, isImageReady, setIsImageReady}: CafeByPlaceProps) => {
+const CafeByPlace = ({ isImageReady, setIsImageReady }: CafeByPlaceProps) => {
     const dispatch = useAppDispatch();
     const setCurrentCafeIndex = (index: number) => dispatch(introNavSlice.actions.navigateToCafe(index));
 
-    if(cafes.length === 1){
-        return  <CarouselMainImage cafe={cafes[0]} isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
+    const currentCafeIndex = useAppSelector(state => state.introNav.currentCafeIndex);
+    const cafeList = useAppSelector(currentIntroCafeListSelector);
+
+    if(cafeList?.length === 1){
+        return  <CarouselMainImage cafe={cafeList[0]} isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
     }
 
     return(
-        <CarouselHorizontal title="Carousel" setCurrentIndex={setCurrentCafeIndex}>
-        {cafes?.map((cafe) => {
+        <CarouselHorizontal
+            title="Carousel"
+            initialIndex={currentCafeIndex}
+            setCurrentIndex={setCurrentCafeIndex}
+        >
+        {cafeList?.map((cafe) => {
             return(
                 <StyledCarouselImage key={cafe.id}>
                     <CarouselMainImage cafe={cafe} isImageReady={isImageReady} setIsImageReady={setIsImageReady} />

--- a/app/src/components/others/CarouselHorizontal/index.tsx
+++ b/app/src/components/others/CarouselHorizontal/index.tsx
@@ -8,12 +8,21 @@ import './index.css';
 interface CarouselHorizontalProps {
     title: string;
     children?: React.ReactNode;
+    initialIndex?: number;
     setCurrentIndex: (index: number) => void;
 }
 
 const CarouselHorizontal: React.FC<CarouselHorizontalProps> = (props) => {
-    const [state, dispatch] = useReducer(reducerCarousel, {pos: 0, sliding: false, dir: RIGHT});
     const numItems = React.Children.count(props.children);
+    const [state, dispatch] = useReducer(
+        reducerCarousel,
+        {
+            pos: props.initialIndex !== undefined
+                ? (props.initialIndex + numItems - 1) % numItems
+                : 0,
+            sliding: false,
+            dir: RIGHT
+        });
     const { setCurrentIndex, children } = props;
 
     useEffect(() => {

--- a/app/src/components/others/CarouselHorizontal/index.tsx
+++ b/app/src/components/others/CarouselHorizontal/index.tsx
@@ -12,7 +12,7 @@ interface CarouselHorizontalProps {
     setCurrentIndex: (index: number) => void;
 }
 
-const CarouselHorizontal: React.FC<CarouselHorizontalProps> = (props) => {
+const CarouselHorizontal = (props: CarouselHorizontalProps) => {
     const numItems = React.Children.count(props.children);
     const [state, dispatch] = useReducer(
         reducerCarousel,

--- a/app/src/components/others/CarouselHorizontal/index.tsx
+++ b/app/src/components/others/CarouselHorizontal/index.tsx
@@ -11,23 +11,19 @@ interface CarouselHorizontalProps {
     setCurrentIndex: (index: number) => void;
 }
 
-const CarouselHorizontal = React.forwardRef<number, CarouselHorizontalProps>((props, ref) => {
+const CarouselHorizontal: React.FC<CarouselHorizontalProps> = (props) => {
     const [state, dispatch] = useReducer(reducerCarousel, {pos: 0, sliding: false, dir: RIGHT});
     const numItems = React.Children.count(props.children);
     const { setCurrentIndex, children } = props;
 
     useEffect(() => {
-        if (typeof ref === 'function') {
-            return;
-        }
-
         React.Children.toArray(props.children).forEach((child, index) => {
             let order = getOrder(index, state.pos, numItems); 
             if(order === 1){
                 setCurrentIndex(index);
             }
         })
-    }, [numItems, props.children, ref, setCurrentIndex, state.pos])
+    }, [numItems, props.children, setCurrentIndex, state.pos])
 
     const slide =  (dir: string) => {
         dispatch({type: dir, numItems: numItems});
@@ -55,6 +51,6 @@ const CarouselHorizontal = React.forwardRef<number, CarouselHorizontalProps>((pr
             </div>
         </div>
     )
-})
+};
 
 export default CarouselHorizontal;

--- a/app/src/components/others/PlaceSlide/index.tsx
+++ b/app/src/components/others/PlaceSlide/index.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import introNavSlice from '../../../store/modules/intro-nav';
 import { StyledRowFlex } from '../../../utils/styled';
 import { TypePlace } from '../../../utils/type';
 import './index.css';
 
 type PlaceSlideProps = {
     places: TypePlace[];
-    currentPlaceIndex: number;
-    setCurrentPlaceIndex: (index: number) => void;
 }
 
-const PlaceSlide = ({places, currentPlaceIndex, setCurrentPlaceIndex}: PlaceSlideProps) => {
-    const handleClick = (index: number) => {
-        setCurrentPlaceIndex(index);
-;    }
+const PlaceSlide = ({places}: PlaceSlideProps) => {
+    const dispatch = useAppDispatch();
+    const handleClick = (index: number) => dispatch(introNavSlice.actions.navigateToPlace(index));
  
+    const currentPlaceIndex = useAppSelector(state => state.introNav.currentPlaceIndex);
+
     return(
         <StyledRowFlex className="place-container">
             {places.map((place, index) => {

--- a/app/src/components/pages/Intro/index.tsx
+++ b/app/src/components/pages/Intro/index.tsx
@@ -6,14 +6,16 @@ import { getCafeListByPlace, getPlaceList } from '../../api';
 import PlaceSlide from '../../others/PlaceSlide';
 import CafeByPlace from '../../others/CafeByPlace';
 import InitialLoading from '../../others/InitialLoading';
+import { useAppSelector } from '../../../store/hooks';
 import './index.css';
 
 const Intro = () => {
     const [places, setPlaces] = useState<TypePlace[]>([]);
-    const [currentPlaceIndex, setCurrentPlaceIndex] = useState<number>(0);
     const [cafes, setCafes] = useState<TypeCafe[] | null>(null)
-    const [currentCafeIndex, setCurrentCafeIndex] = useState<number>(0);
     const [isImageReady, setIsImageReady] = useState<boolean>(false);
+
+    const currentPlaceIndex = useAppSelector(state => state.introNav.currentPlaceIndex);
+    const currentCafeIndex = useAppSelector(state => state.introNav.currentCafeIndex);
 
     useEffect(() => {
         const fetchData = async () => {
@@ -50,13 +52,13 @@ const Intro = () => {
                             <span className="cafe-preview-info-list">OPEN {cafes[currentCafeIndex]?.metadata?.hour}</span>
                             <span className="cafe-preview-info-by">{cafes[currentCafeIndex]?.metadata?.creator || 'jyuunnii'} 님이 올려주신 {cafes[currentCafeIndex]?.name}</span>
                         </div>
-                        <CafeByPlace cafes={cafes} setCurrentCafeIndex={setCurrentCafeIndex} isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
+                        <CafeByPlace cafes={cafes} isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
                         <StyledRowFlex className="cafe-preview-websearch">
                             <span onClick={() => openSearch((cafes[currentCafeIndex]?.name)+" "+cafes[currentCafeIndex].place.name, "Naver")}><b className="web-naver">N</b> 네이버 바로가기</span>
                             <span onClick={() => openSearch((cafes[currentCafeIndex]?.name), "Instagram")}><b className="web-instagram">I</b> 인스타그램 바로가기</span>       
                         </StyledRowFlex>
                     </div>
-                    <PlaceSlide places={places} currentPlaceIndex={currentPlaceIndex} setCurrentPlaceIndex={setCurrentPlaceIndex}/>
+                    <PlaceSlide places={places} />
                 </StyledColumnFlex>
             }  
         </StyledMainScale>

--- a/app/src/components/pages/Intro/index.tsx
+++ b/app/src/components/pages/Intro/index.tsx
@@ -5,7 +5,7 @@ import PlaceSlide from '../../others/PlaceSlide';
 import CafeByPlace from '../../others/CafeByPlace';
 import InitialLoading from '../../others/InitialLoading';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
-import { fetchCafesInPlace, fetchPlaces } from '../../../store/modules/cafe';
+import { fetchCafesByPlace, fetchPlaces } from '../../../store/modules/cafe';
 import { currentIntroCafeSelector, currentIntroPlaceSelector } from '../../../store/selectors/cafe';
 import './index.css';
 
@@ -25,7 +25,7 @@ const Intro = () => {
 
     useEffect(() => {
         if (currentPlace) {
-            dispatch(fetchCafesInPlace(currentPlace));
+            dispatch(fetchCafesByPlace(currentPlace));
         }
     }, [dispatch, currentPlace]);
 

--- a/app/src/components/pages/Intro/index.tsx
+++ b/app/src/components/pages/Intro/index.tsx
@@ -1,64 +1,52 @@
 import React, { useEffect, useState } from 'react';
 import { openSearch } from '../../../utils/function';
 import { StyledColumnFlex, StyledMainScale, StyledRowFlex } from '../../../utils/styled';
-import { TypeCafe, TypePlace } from '../../../utils/type';
-import { getCafeListByPlace, getPlaceList } from '../../api';
 import PlaceSlide from '../../others/PlaceSlide';
 import CafeByPlace from '../../others/CafeByPlace';
 import InitialLoading from '../../others/InitialLoading';
-import { useAppSelector } from '../../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import { fetchCafesInPlace, fetchPlaces } from '../../../store/modules/cafe';
+import { currentIntroCafeSelector, currentIntroPlaceSelector } from '../../../store/selectors/cafe';
 import './index.css';
 
 const Intro = () => {
-    const [places, setPlaces] = useState<TypePlace[]>([]);
-    const [cafes, setCafes] = useState<TypeCafe[] | null>(null)
+    const dispatch = useAppDispatch();
+
     const [isImageReady, setIsImageReady] = useState<boolean>(false);
 
-    const currentPlaceIndex = useAppSelector(state => state.introNav.currentPlaceIndex);
-    const currentCafeIndex = useAppSelector(state => state.introNav.currentCafeIndex);
+    const places = useAppSelector(state => state.cafe.place?.list);
+
+    const currentPlace = useAppSelector(currentIntroPlaceSelector);
+    const currentCafe = useAppSelector(currentIntroCafeSelector);
 
     useEffect(() => {
-        const fetchData = async () => {
-            await getPlaceList().then(data => {
-                if(data){
-                    setPlaces(data.place.list)
-                }
-            })
-        }
-        fetchData();
-    },[])
+        dispatch(fetchPlaces());
+    }, [dispatch]);
 
     useEffect(() => {
-        if(places.length > 0){
-            const fetchData = async (place: TypePlace) => {
-                await getCafeListByPlace(place.name).then(data => {
-                    if(data.cafe) {
-                        setCafes(data.cafe.list);
-                    }
-                });
-            }
-            fetchData(places[currentPlaceIndex]);
+        if (currentPlace) {
+            dispatch(fetchCafesInPlace(currentPlace));
         }
-    }, [currentPlaceIndex, places])
+    }, [dispatch, currentPlace]);
 
     return(
         <StyledMainScale>
             {!isImageReady && <InitialLoading/> }
-            {cafes && 
+            {currentCafe && 
                 <StyledColumnFlex className="intro" style={{display: isImageReady? 'block' : 'none'}}>
                     <div className="carousel-container">
                         <div className="cafe-preview-info">
-                            <h4>{cafes[currentCafeIndex]?.name}</h4>
-                            <span className="cafe-preview-info-list">OPEN {cafes[currentCafeIndex]?.metadata?.hour}</span>
-                            <span className="cafe-preview-info-by">{cafes[currentCafeIndex]?.metadata?.creator || 'jyuunnii'} 님이 올려주신 {cafes[currentCafeIndex]?.name}</span>
+                            <h4>{currentCafe?.name}</h4>
+                            <span className="cafe-preview-info-list">OPEN {currentCafe?.metadata?.hour}</span>
+                            <span className="cafe-preview-info-by">{currentCafe?.metadata?.creator || 'jyuunnii'} 님이 올려주신 {currentCafe?.name}</span>
                         </div>
-                        <CafeByPlace cafes={cafes} isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
+                        <CafeByPlace isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
                         <StyledRowFlex className="cafe-preview-websearch">
-                            <span onClick={() => openSearch((cafes[currentCafeIndex]?.name)+" "+cafes[currentCafeIndex].place.name, "Naver")}><b className="web-naver">N</b> 네이버 바로가기</span>
-                            <span onClick={() => openSearch((cafes[currentCafeIndex]?.name), "Instagram")}><b className="web-instagram">I</b> 인스타그램 바로가기</span>       
+                            <span onClick={() => openSearch((currentCafe?.name)+" "+currentCafe.place.name, "Naver")}><b className="web-naver">N</b> 네이버 바로가기</span>
+                            <span onClick={() => openSearch((currentCafe?.name), "Instagram")}><b className="web-instagram">I</b> 인스타그램 바로가기</span>       
                         </StyledRowFlex>
                     </div>
-                    <PlaceSlide places={places} />
+                    { places && <PlaceSlide places={places} /> }
                 </StyledColumnFlex>
             }  
         </StyledMainScale>

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
 import App from './components/App';
 import './index.css';
 
 import reportWebVitals from './reportWebVitals';
+import store from './store';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/app/src/store/exception.ts
+++ b/app/src/store/exception.ts
@@ -1,0 +1,1 @@
+export class DataAlreadyLoadedException extends Error {}

--- a/app/src/store/hooks.ts
+++ b/app/src/store/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from ".";
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import introNavSlice from './modules/intro-nav';
+
+const store = configureStore({
+  reducer: {
+    introNav: introNavSlice.reducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+
+export default store;

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
+import cafeSlice from './modules/cafe';
 import introNavSlice from './modules/intro-nav';
 
 const store = configureStore({
   reducer: {
     introNav: introNavSlice.reducer,
+    cafe: cafeSlice.reducer,
   },
 });
 

--- a/app/src/store/modules/cafe.ts
+++ b/app/src/store/modules/cafe.ts
@@ -35,12 +35,12 @@ export const fetchPlaces = createAsyncThunk<
   },
 );
 
-export const fetchCafesInPlace = createAsyncThunk<
+export const fetchCafesByPlace = createAsyncThunk<
   { placeId: string; list: TypeCafe[]; },
   TypePlace,
   { state: RootState }
 >(
-  'cafe/fetchCafesInPlace',
+  'cafe/fetchCafesByPlace',
   async (place: TypePlace, { getState }) => {
     const cafeRecord = getState().cafe.cafeMap[place.id];
     if (cafeRecord) {
@@ -68,7 +68,7 @@ const cafeSlice = createSlice({
     );
 
     builder.addCase(
-      fetchCafesInPlace.fulfilled,
+      fetchCafesByPlace.fulfilled,
       (state, action) => {
         state.cafeMap[action.payload.placeId] = {
           list: action.payload.list

--- a/app/src/store/modules/cafe.ts
+++ b/app/src/store/modules/cafe.ts
@@ -1,0 +1,81 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { RootState } from "..";
+import { getCafeListByPlace, getPlaceList } from "../../components/api";
+import { TypeCafe, TypePlace } from "../../utils/type";
+import { DataAlreadyLoadedException } from "../exception";
+
+type CafeState = {
+  place?: {
+    list: TypePlace[];
+  };
+  cafeMap: {
+    [placeId: string]: {
+      list: TypeCafe[];
+    }
+  }
+};
+
+const initialState: CafeState = {
+  cafeMap: {}
+};
+
+export const fetchPlaces = createAsyncThunk<
+  TypePlace[],
+  void,
+  { state: RootState }
+>(
+  'cafe/fetchPlaces',
+  async (_, { getState }) => {
+    if (getState().cafe.place) {
+      throw new DataAlreadyLoadedException();
+    }
+
+    const response = await getPlaceList();
+    return response.place.list;
+  },
+);
+
+export const fetchCafesInPlace = createAsyncThunk<
+  { placeId: string; list: TypeCafe[]; },
+  TypePlace,
+  { state: RootState }
+>(
+  'cafe/fetchCafesInPlace',
+  async (place: TypePlace, { getState }) => {
+    const cafeRecord = getState().cafe.cafeMap[place.id];
+    if (cafeRecord) {
+      throw new DataAlreadyLoadedException();
+    }
+
+    const response = await getCafeListByPlace(place.name);
+    return {
+      placeId: place.id,
+      list: response.cafe.list
+    };
+  },
+)
+
+const cafeSlice = createSlice({
+  name: 'cafe',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(
+      fetchPlaces.fulfilled,
+      (state, action) => {
+        state.place = { list: action.payload };
+      }
+    );
+
+    builder.addCase(
+      fetchCafesInPlace.fulfilled,
+      (state, action) => {
+        state.cafeMap[action.payload.placeId] = {
+          list: action.payload.list
+        };
+      }
+    );
+  },
+});
+
+export default cafeSlice;

--- a/app/src/store/modules/intro-nav.ts
+++ b/app/src/store/modules/intro-nav.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+type IntroNavState = {
+  currentPlaceIndex: number;
+  currentCafeIndex: number;
+};
+
+const initialState: IntroNavState = {
+  currentPlaceIndex: 0,
+  currentCafeIndex: 0,
+};
+
+const introNavSlice = createSlice({
+  name: 'introNav',
+  initialState,
+  reducers: {
+    navigateToPlace(state, action: PayloadAction<number>) {
+      state.currentPlaceIndex = action.payload;
+      state.currentCafeIndex = 0;
+    },
+    navigateToCafe(state, action: PayloadAction<number>) {
+      state.currentCafeIndex = action.payload;
+    }
+  },
+});
+
+export default introNavSlice;

--- a/app/src/store/selectors/cafe.ts
+++ b/app/src/store/selectors/cafe.ts
@@ -1,0 +1,46 @@
+import { createSelector } from "reselect";
+import { RootState } from "..";
+import { TypeCafe, TypePlace } from "../../utils/type";
+
+export const currentIntroPlaceSelector = createSelector<
+  RootState, 
+  TypePlace[] | undefined, 
+  number, 
+  TypePlace | undefined
+>(
+  (state) => state.cafe.place?.list,
+  (state) => state.introNav.currentPlaceIndex,
+  (places, currentPlaceIndex) => {
+    return places?.[currentPlaceIndex];
+  }
+);
+
+export const currentIntroCafeListSelector = createSelector<
+  RootState,
+  TypePlace | undefined,
+  { [placeId: string]: { list: TypeCafe[]; } },
+  TypeCafe[] | undefined
+>(
+  currentIntroPlaceSelector,
+  (state) => state.cafe.cafeMap,
+  (place, cafeMap) => {
+    if (!place) {
+      return undefined;
+    }
+
+    return cafeMap[place.id]?.list;
+  }
+);
+
+export const currentIntroCafeSelector = createSelector<
+  RootState,
+  TypeCafe[] | undefined,
+  number,
+  TypeCafe | undefined
+>(
+  currentIntroCafeListSelector,
+  (state) => state.introNav.currentCafeIndex,
+  (cafeList, currentCafeIndex) => {
+    return cafeList?.[currentCafeIndex];
+  }
+);


### PR DESCRIPTION
- Navigation state (current place, cafe index)을 redux state로 올려서 관리합니다.
  - 이에 따라 필요한 패키지인 `redux`, `react-redux`, `@reduxjs/toolkit` 을 설치합니다.
- 네트워크 요청 (`GET /place/list`, `GET /cafe/feed`) 을 redux middleware에서 처리합니다.
- 네트워크 요청을 1번 이상 보내지 않습니다. (결과를 redux state에 저장)
- `CarouselHorizontal` 컴포넌트 prop에 `initialIndex` 필드를 추가합니다. 이를 이용하여, 세부 페이지에서 다시 홈으로 나올 때 redux에 저장된 인덱스를 초기 상태로 지정합니다.