### PR TITLE
feat: 이미지 로드 전 화면 공백 현상 해결

### DIFF
--- a/app/src/components/Router.tsx
+++ b/app/src/components/Router.tsx
@@ -10,7 +10,7 @@ const CafeDetailPage = lazy(() => import("./pages/Detail"));
 
 const Router = (props: RouterProps) => {
   return(
-      <React.Suspense fallback={<div>Loading...</div>}>
+      <React.Suspense fallback={<div></div>}>
         <Switch location={props.location}>    
             <Route path="/" exact render={() => <IntroPage />}/>
             <Route path="/cafe/:cafeId" exact render={() => <CafeDetailPage/>}/>

--- a/app/src/components/others/CafeByPlace/index.tsx
+++ b/app/src/components/others/CafeByPlace/index.tsx
@@ -6,12 +6,7 @@ import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import introNavSlice from '../../../store/modules/intro-nav';
 import { currentIntroCafeListSelector } from '../../../store/selectors/cafe';
 
-type CafeByPlaceProps = {
-    isImageReady: boolean;
-    setIsImageReady: (isImageReady: boolean) => void;
-}
-
-const CafeByPlace = ({ isImageReady, setIsImageReady }: CafeByPlaceProps) => {
+const CafeByPlace = () => {
     const dispatch = useAppDispatch();
     const setCurrentCafeIndex = (index: number) => dispatch(introNavSlice.actions.navigateToCafe(index));
 
@@ -19,7 +14,7 @@ const CafeByPlace = ({ isImageReady, setIsImageReady }: CafeByPlaceProps) => {
     const cafeList = useAppSelector(currentIntroCafeListSelector);
 
     if(cafeList?.length === 1){
-        return  <CarouselMainImage cafe={cafeList[0]} isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
+        return  <CarouselMainImage cafe={cafeList[0]} index={0}/>
     }
 
     return(
@@ -28,10 +23,10 @@ const CafeByPlace = ({ isImageReady, setIsImageReady }: CafeByPlaceProps) => {
             initialIndex={currentCafeIndex}
             setCurrentIndex={setCurrentCafeIndex}
         >
-        {cafeList?.map((cafe) => {
+        {cafeList?.map((cafe, index) => {
             return(
                 <StyledCarouselImage key={cafe.id}>
-                    <CarouselMainImage cafe={cafe} isImageReady={isImageReady} setIsImageReady={setIsImageReady} />
+                    <CarouselMainImage cafe={cafe} index={index}/>
                 </StyledCarouselImage>
         )})}
         </CarouselHorizontal>

--- a/app/src/components/others/CafeCarousel/index.tsx
+++ b/app/src/components/others/CafeCarousel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { TypeCafe } from '../../../utils/type';
 import CarouselMainImage from '../CarouselMainImage';
 import './index.css';
@@ -10,13 +10,11 @@ type CafeImageCarouselProps = {
 }
 
 const CafeCarousel = ({cafes}: CafeImageCarouselProps) => {
-    const [isImageReady, setIsImageReady] = useState<boolean>(false);
-
     if(cafes.length === 1) {
         return (
             <div>
                 <StyledCarouselImage>
-                    <CarouselMainImage cafe={cafes[0]} isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
+                    <CarouselMainImage cafe={cafes[0]} index={0} />
                 </StyledCarouselImage>
             </div>
         )
@@ -24,10 +22,10 @@ const CafeCarousel = ({cafes}: CafeImageCarouselProps) => {
     return(
         <div className="carousel-container">
             <CarouselVertical title="Carousel">
-            {cafes?.map((cafe) => {
+            {cafes?.map((cafe, index) => {
                 return(
                     <StyledCarouselImage key={cafe.id}>
-                        <CarouselMainImage cafe={cafe} isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
+                        <CarouselMainImage cafe={cafe} index={index}/>
                     </StyledCarouselImage>
             )})}
             </CarouselVertical>

--- a/app/src/components/others/CarouselMainImage/index.tsx
+++ b/app/src/components/others/CarouselMainImage/index.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useAppDispatch } from '../../../store/hooks';
+import introNavSlice from '../../../store/modules/intro-nav';
 import { onImageLoad } from '../../../utils/function';
 import { StyledSpinnerContainer } from '../../../utils/styled';
 import { TypeCafe } from '../../../utils/type';
@@ -8,11 +10,11 @@ import './index.css';
 
 type CarouselMainImageProps = {
     cafe: TypeCafe;
-    isImageReady: boolean;
-    setIsImageReady: (isImageReady: boolean) => void;
+    index: number;
 }
 
-const CarouselMainImage = ({cafe, isImageReady, setIsImageReady}: CarouselMainImageProps) => {
+const CarouselMainImage = ({cafe, index}: CarouselMainImageProps) => {
+    const [isImageReady, setImageReady] = useState(false);
     const history = useHistory();
     const mainImage = cafe.image.list.find((image) => image.isMain);
 
@@ -21,12 +23,18 @@ const CarouselMainImage = ({cafe, isImageReady, setIsImageReady}: CarouselMainIm
             pathname: `/cafe/${cafe.id}`,
         })
     }
+    
+    const dispatch = useAppDispatch();
+    const handleLoad = () => {
+        onImageLoad(setImageReady);
+        dispatch(introNavSlice.actions.setImageReady(index));
+    }
 
     return(
         <div className="carousel-img">
             {mainImage && <img src={cafe.image.count > 0 ? mainImage.relativeUri : "/images/coffee.png"} alt="img" 
                 style={{display: isImageReady ? "initial" : "none"}} 
-                onLoad={() => onImageLoad(setIsImageReady)}
+                onLoad={handleLoad}
                 onClick={handleClick}/>}
             <StyledSpinnerContainer visible={!isImageReady} size={document.body.clientWidth}>
                 <Spinner size={24}/>

--- a/app/src/components/others/PlaceSlide/index.tsx
+++ b/app/src/components/others/PlaceSlide/index.tsx
@@ -7,15 +7,11 @@ import './index.css';
 
 type PlaceSlideProps = {
     places: TypePlace[];
-    setInitialClick: (hasInitialClick: boolean) => void;
 }
 
-const PlaceSlide = ({places, setInitialClick}: PlaceSlideProps) => {
+const PlaceSlide = ({places}: PlaceSlideProps) => {
     const dispatch = useAppDispatch();
-    const handleClick = (index: number) => {
-        setInitialClick(true);
-        dispatch(introNavSlice.actions.navigateToPlace(index))
-    };
+    const handleClick = (index: number) => dispatch(introNavSlice.actions.navigateToPlace(index));
  
     const currentPlaceIndex = useAppSelector(state => state.introNav.currentPlaceIndex);
 

--- a/app/src/components/others/PlaceSlide/index.tsx
+++ b/app/src/components/others/PlaceSlide/index.tsx
@@ -7,11 +7,15 @@ import './index.css';
 
 type PlaceSlideProps = {
     places: TypePlace[];
+    setInitialClick: (hasInitialClick: boolean) => void;
 }
 
-const PlaceSlide = ({places}: PlaceSlideProps) => {
+const PlaceSlide = ({places, setInitialClick}: PlaceSlideProps) => {
     const dispatch = useAppDispatch();
-    const handleClick = (index: number) => dispatch(introNavSlice.actions.navigateToPlace(index));
+    const handleClick = (index: number) => {
+        setInitialClick(true);
+        dispatch(introNavSlice.actions.navigateToPlace(index))
+    };
  
     const currentPlaceIndex = useAppSelector(state => state.introNav.currentPlaceIndex);
 

--- a/app/src/components/pages/Intro/index.tsx
+++ b/app/src/components/pages/Intro/index.tsx
@@ -16,6 +16,7 @@ const Intro = () => {
     const currentCafe = useAppSelector(currentIntroCafeSelector);
     const isInitialCafeImageReady = useAppSelector(state => state.introNav.isInitialCafeImageReady);
     const hasInitialClick = useAppSelector(state => state.introNav.hasInitialClick);
+    const isInitialLoading = !hasInitialClick && !isInitialCafeImageReady;
 
     useEffect(() => {
         dispatch(fetchPlaces());
@@ -29,9 +30,9 @@ const Intro = () => {
 
     return(
         <StyledMainScale>
-            {!hasInitialClick && !isInitialCafeImageReady && <InitialLoading/> }
+            {isInitialLoading && <InitialLoading/> }
             {currentCafe && 
-                <StyledColumnFlex className="intro" style={{display: !hasInitialClick && !isInitialCafeImageReady? 'none' : 'block'}}>
+                <StyledColumnFlex className="intro" style={{display: isInitialLoading? 'none' : 'block'}}>
                     <div className="carousel-container">
                         <div className="cafe-preview-info">
                             <h4>{currentCafe?.name}</h4>

--- a/app/src/components/pages/Intro/index.tsx
+++ b/app/src/components/pages/Intro/index.tsx
@@ -10,14 +10,12 @@ import { currentIntroCafeSelector, currentIntroPlaceSelector } from '../../../st
 import './index.css';
 
 const Intro = () => {
+    const [hasInitialClick, setInitialClick] = useState(false);
     const dispatch = useAppDispatch();
-
-    const [isImageReady, setIsImageReady] = useState<boolean>(false);
-
     const places = useAppSelector(state => state.cafe.place?.list);
-
     const currentPlace = useAppSelector(currentIntroPlaceSelector);
     const currentCafe = useAppSelector(currentIntroCafeSelector);
+    const isInitialCafeImageReady = useAppSelector(state => state.introNav.isInitialCafeImageReady);
 
     useEffect(() => {
         dispatch(fetchPlaces());
@@ -31,22 +29,22 @@ const Intro = () => {
 
     return(
         <StyledMainScale>
-            {!isImageReady && <InitialLoading/> }
+            {!hasInitialClick && !isInitialCafeImageReady && <InitialLoading/> }
             {currentCafe && 
-                <StyledColumnFlex className="intro" style={{display: isImageReady? 'block' : 'none'}}>
+                <StyledColumnFlex className="intro" style={{display: !hasInitialClick && !isInitialCafeImageReady? 'none' : 'block'}}>
                     <div className="carousel-container">
                         <div className="cafe-preview-info">
                             <h4>{currentCafe?.name}</h4>
                             <span className="cafe-preview-info-list">OPEN {currentCafe?.metadata?.hour}</span>
                             <span className="cafe-preview-info-by">{currentCafe?.metadata?.creator || 'jyuunnii'} 님이 올려주신 {currentCafe?.name}</span>
                         </div>
-                        <CafeByPlace isImageReady={isImageReady} setIsImageReady={setIsImageReady}/>
+                        <CafeByPlace/>
                         <StyledRowFlex className="cafe-preview-websearch">
                             <span onClick={() => openSearch((currentCafe?.name)+" "+currentCafe.place.name, "Naver")}><b className="web-naver">N</b> 네이버 바로가기</span>
                             <span onClick={() => openSearch((currentCafe?.name), "Instagram")}><b className="web-instagram">I</b> 인스타그램 바로가기</span>       
                         </StyledRowFlex>
                     </div>
-                    { places && <PlaceSlide places={places} /> }
+                    { places && <PlaceSlide places={places} setInitialClick={setInitialClick}/> }
                 </StyledColumnFlex>
             }  
         </StyledMainScale>

--- a/app/src/components/pages/Intro/index.tsx
+++ b/app/src/components/pages/Intro/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { openSearch } from '../../../utils/function';
 import { StyledColumnFlex, StyledMainScale, StyledRowFlex } from '../../../utils/styled';
 import PlaceSlide from '../../others/PlaceSlide';
@@ -10,12 +10,12 @@ import { currentIntroCafeSelector, currentIntroPlaceSelector } from '../../../st
 import './index.css';
 
 const Intro = () => {
-    const [hasInitialClick, setInitialClick] = useState(false);
     const dispatch = useAppDispatch();
     const places = useAppSelector(state => state.cafe.place?.list);
     const currentPlace = useAppSelector(currentIntroPlaceSelector);
     const currentCafe = useAppSelector(currentIntroCafeSelector);
     const isInitialCafeImageReady = useAppSelector(state => state.introNav.isInitialCafeImageReady);
+    const hasInitialClick = useAppSelector(state => state.introNav.hasInitialClick);
 
     useEffect(() => {
         dispatch(fetchPlaces());
@@ -44,7 +44,7 @@ const Intro = () => {
                             <span onClick={() => openSearch((currentCafe?.name), "Instagram")}><b className="web-instagram">I</b> 인스타그램 바로가기</span>       
                         </StyledRowFlex>
                     </div>
-                    { places && <PlaceSlide places={places} setInitialClick={setInitialClick}/> }
+                    { places && <PlaceSlide places={places} /> }
                 </StyledColumnFlex>
             }  
         </StyledMainScale>

--- a/app/src/store/modules/intro-nav.ts
+++ b/app/src/store/modules/intro-nav.ts
@@ -4,12 +4,14 @@ type IntroNavState = {
   currentPlaceIndex: number;
   currentCafeIndex: number;
   isInitialCafeImageReady: boolean;
+  hasInitialClick: boolean;
 };
 
 const initialState: IntroNavState = {
   currentPlaceIndex: 0,
   currentCafeIndex: 0,
   isInitialCafeImageReady: false,
+  hasInitialClick: false,
 };
 
 const introNavSlice = createSlice({
@@ -17,7 +19,7 @@ const introNavSlice = createSlice({
   initialState,
   reducers: {
     navigateToPlace(state, action: PayloadAction<number>) {
-      state.isInitialCafeImageReady = false;
+      state.hasInitialClick = true;
       state.currentPlaceIndex = action.payload;
       state.currentCafeIndex = 0;
     },
@@ -25,7 +27,7 @@ const introNavSlice = createSlice({
       state.currentCafeIndex = action.payload;
     },
     setImageReady(state, action: PayloadAction<number>) {
-      if(action.payload === 0) {
+      if(action.payload === initialState.currentCafeIndex) {
         state.isInitialCafeImageReady = true;
       }
     }

--- a/app/src/store/modules/intro-nav.ts
+++ b/app/src/store/modules/intro-nav.ts
@@ -3,11 +3,13 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 type IntroNavState = {
   currentPlaceIndex: number;
   currentCafeIndex: number;
+  isInitialCafeImageReady: boolean;
 };
 
 const initialState: IntroNavState = {
   currentPlaceIndex: 0,
   currentCafeIndex: 0,
+  isInitialCafeImageReady: false,
 };
 
 const introNavSlice = createSlice({
@@ -15,11 +17,17 @@ const introNavSlice = createSlice({
   initialState,
   reducers: {
     navigateToPlace(state, action: PayloadAction<number>) {
+      state.isInitialCafeImageReady = false;
       state.currentPlaceIndex = action.payload;
       state.currentCafeIndex = 0;
     },
     navigateToCafe(state, action: PayloadAction<number>) {
       state.currentCafeIndex = action.payload;
+    },
+    setImageReady(state, action: PayloadAction<number>) {
+      if(action.payload === 0) {
+        state.isInitialCafeImageReady = true;
+      }
     }
   },
 });


### PR DESCRIPTION
### Changes
- 라우터 fallback 시 렌더되는 부분 수정 : `Loading...` 텍스트 제거
- 이미지 로드 상태는 개별적으로 관리하도록 수정: `CarouselMainImage` 내에서 상태 관리
- splash 노출 조건 변경 
수정 전 : 최초의 이미지 로드가 완료되기 전 까지 노출
수정 후 : 유저 클릭 이벤트 발생 전 && 첫번째 장소의 첫번째 카페 이미지 로드가 완료되기 전 까지 노출

### Notes
'유저 클릭 이벤트 발생 전 === 최초의 렌더' 로 가정 -> 스플래시는 처음 진입 시에만 나타나야하기 때문에