### PR TITLE
/cafe/count, /cafe/list API에서 keyword query에 cafe.place 고려하기

### DIFF
--- a/services/http-api/src/routes/cafe/cafe.control.ts
+++ b/services/http-api/src/routes/cafe/cafe.control.ts
@@ -229,6 +229,7 @@ export const getCount = handler<
 
     let query = getManager()
       .createQueryBuilder(Cafe, 'cafe')
+      .leftJoinAndSelect('cafe.place', 'place')
       .where(`"cafe"."state" IS DISTINCT FROM :deleted`, {
         deleted: CafeState.deleted,
       });
@@ -240,9 +241,12 @@ export const getCount = handler<
     }
 
     if (keyword) {
-      query = query.andWhere(`"cafe"."name" LIKE :keyword`, {
-        keyword: `%${keyword}%`,
-      });
+      query = query.andWhere(
+        `("cafe"."name" LIKE :keyword OR "place"."name" LIKE :keyword)`,
+        {
+          keyword: `%${keyword}%`,
+        }
+      );
     }
 
     const count = await query.getCount();
@@ -413,9 +417,12 @@ export const getList = handler<
     }
 
     if (keyword) {
-      query = query.andWhere(`cafe.name LIKE :keyword`, {
-        keyword: `%${keyword}%`,
-      });
+      query = query.andWhere(
+        `(cafe.name LIKE :keyword OR place.name LIKE :keyword)`,
+        {
+          keyword: `%${keyword}%`,
+        }
+      );
     }
 
     switch (orderBy) {

--- a/services/http-api/src/routes/cafe/list.test.ts
+++ b/services/http-api/src/routes/cafe/list.test.ts
@@ -423,6 +423,30 @@ describe('Cafe - GET /cafe/count', () => {
 
     expect(count).toBe(activeCafeIds.length);
   });
+
+  test('Can retrieve number of cafes using place', async () => {
+    const responsePankyo = await request
+      .get('/cafe/count')
+      .query({ keyword: '판교' })
+      .expect(HTTP_OK);
+
+    const {
+      cafe: { count: countPankyo },
+    } = responsePankyo.body as { cafe: { count: number } };
+
+    expect(countPankyo).toBe(activeCafeIds.length);
+
+    const responseGangnam = await request
+      .get('/cafe/count')
+      .query({ keyword: '강남' })
+      .expect(HTTP_OK);
+
+    const {
+      cafe: { count: countGangnam },
+    } = responseGangnam.body as { cafe: { count: number } };
+
+    expect(countGangnam).toBe(0);
+  });
 });
 
 describe('Cafe - GET /cafe/list', () => {
@@ -485,9 +509,13 @@ describe('Cafe - GET /cafe/list', () => {
   });
 
   test('Can list cafes using keyword', async () => {
-    const cafes = await sweepCafes('/cafe/list', { keyword: '성수동' });
+    const cafesEmpty = await sweepCafes('/cafe/list', { keyword: '성수동' });
 
-    expect(cafes.length).toBe(0);
+    expect(cafesEmpty.length).toBe(0);
+
+    const cafes = await sweepCafes('/cafe/list', { keyword: '판교' });
+
+    expect(cafes.length).toBe(activeCafeIds.length);
   });
 
   test('Can count hidden cafe images', async () => {


### PR DESCRIPTION
### Changes
- 관련 테스트 추가
- 쿼리에서 keyword 관련 clause 수정

**AS-IS**
```
query = query.andWhere(`cafe.name LIKE :keyword`, {
  keyword: `%${keyword}%`,
});
```
**TO-BE**
```
query = query.andWhere(
  `("cafe"."name" LIKE :keyword OR "place"."name" LIKE :keyword)`,
  {
    keyword: `%${keyword}%`,
  }
);
```

Closes #88 