### PR TITLE
feat: 흠링크 복사 기능 추가

### DIFF
--- a/mobile_app/lib/detail_button.dart
+++ b/mobile_app/lib/detail_button.dart
@@ -16,7 +16,7 @@ class DetailButtonSet extends StatelessWidget {
                     text: '흠 링크\n복사하기',
                     imgSrc: 'assets/images/Hmm_icon.png',
                     onPressed: () => handleLinkShareClick(
-                        'https://www.coffeehmm.com/cafe/$cafeId', context))),
+                        'https://www.coffeehmm.com/cafe/$cafeId'))),
             Expanded(
                 child: DetailButton(
                     text: '네이버\n바로가기',

--- a/mobile_app/lib/detail_button.dart
+++ b/mobile_app/lib/detail_button.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:mobile_app/util.dart';
 
 class DetailButtonSet extends StatelessWidget {
+  final String cafeId;
+
+  DetailButtonSet({required this.cafeId});
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -12,7 +15,8 @@ class DetailButtonSet extends StatelessWidget {
                 child: DetailButton(
                     text: '흠 링크\n복사하기',
                     imgSrc: 'assets/images/Hmm_icon.png',
-                    onPressed: handleLinkShareClick)),
+                    onPressed: () => handleLinkShareClick(
+                        'https://www.coffeehmm.com/cafe/$cafeId', context))),
             Expanded(
                 child: DetailButton(
                     text: '네이버\n바로가기',

--- a/mobile_app/lib/detail_page.dart
+++ b/mobile_app/lib/detail_page.dart
@@ -68,7 +68,7 @@ class _DetailBodyState extends State<DetailBody> {
           currentIndex: currentIndex ?? 0,
         ),
         CafeMinimumInfo(cafe: cafe),
-        DetailButtonSet(),
+        DetailButtonSet(cafeId: cafe.id),
       ],
     );
   }

--- a/mobile_app/lib/util.dart
+++ b/mobile_app/lib/util.dart
@@ -1,23 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 
-void handleLinkShareClick(String link, BuildContext context) {
+void handleLinkShareClick(String link) {
   Clipboard.setData(ClipboardData(text: link));
-  showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context) {
-        Future.delayed(Duration(seconds: 1), () {
-          Navigator.pop(context);
-        });
-        return AlertDialog(
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-          insetPadding: EdgeInsets.symmetric(horizontal: 80, vertical: 20),
-          content: Text('커피흠 링크가 복사되었습니다.',
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 12, color: Colors.black)),
-        );
-      });
+  Fluttertoast.showToast(
+    msg: '커피흠 링크가 복사되었습니다.',
+    backgroundColor: Colors.white,
+    textColor: Colors.black,
+  );
 }
 
 void handleNaverClick() {

--- a/mobile_app/lib/util.dart
+++ b/mobile_app/lib/util.dart
@@ -1,5 +1,23 @@
-void handleLinkShareClick() {
-  print('share click!');
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+void handleLinkShareClick(String link, BuildContext context) {
+  Clipboard.setData(ClipboardData(text: link));
+  showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        Future.delayed(Duration(seconds: 1), () {
+          Navigator.pop(context);
+        });
+        return AlertDialog(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          insetPadding: EdgeInsets.symmetric(horizontal: 80, vertical: 20),
+          content: Text('커피흠 링크가 복사되었습니다.',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 12, color: Colors.black)),
+        );
+      });
 }
 
 void handleNaverClick() {

--- a/mobile_app/pubspec.lock
+++ b/mobile_app/pubspec.lock
@@ -130,6 +130,18 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fluttertoast:
+    dependency: "direct main"
+    description:
+      name: fluttertoast
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.0.8"
   http:
     dependency: "direct main"
     description:
@@ -144,6 +156,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3"
   matcher:
     dependency: transitive
     description:

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   cached_network_image: ^3.1.0
   meta: ^1.3.0
   flutter_svg: ^0.22.0
+  fluttertoast: ^8.0.8
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### Changes
- 디테일 페이지 내`흠링크 복사하기` 버튼 이벤트 추가
- 클릭 시 해당 카페의 웹 주소 `https://www.coffeehmm.com/cafe/cafeId` 복사 후 toast 메세지 노출

### Screenshots
https://user-images.githubusercontent.com/40883884/129039176-f7d4c2d4-5f54-4bf3-ab25-2d315f8413fb.mov




