### PR TITLE
feat: Navigator 구현 고도화 및 앱 정보 페이지 추가

### DIFF
--- a/mobile_app/lib/api.dart
+++ b/mobile_app/lib/api.dart
@@ -29,3 +29,16 @@ Future<CafeListResponse> fetchCafeListByPlace(PlaceModel place) async {
     throw Exception('Failed to load cafe list');
   }
 }
+
+Future<SingleCafeResponse> fetchCafe(String cafeId) async {
+  final response = await http.get(
+      Uri.parse('https://release.api.coffee-hmm.inhibitor.io/cafe/$cafeId'));
+
+  if (response.statusCode == 200) {
+    final jsonResponse = json.decode(response.body);
+
+    return SingleCafeResponse.fromJson(jsonResponse);
+  } else {
+    throw Exception('Failed to load cafe');
+  }
+}

--- a/mobile_app/lib/detail_page.dart
+++ b/mobile_app/lib/detail_page.dart
@@ -6,20 +6,6 @@ import 'package:mobile_app/detail_button.dart';
 import 'package:mobile_app/header.dart';
 import 'package:mobile_app/type.dart';
 
-class CafeDetailPage extends Page {
-  final String cafeId;
-
-  CafeDetailPage({required this.cafeId}) : super(key: ValueKey(cafeId));
-
-  Route createRoute(BuildContext context) {
-    return MaterialPageRoute(
-        settings: this,
-        builder: (BuildContext context) {
-          return CafeDetailScreen(cafeId: cafeId);
-        });
-  }
-}
-
 class CafeDetailScreen extends StatelessWidget {
   final String cafeId;
 
@@ -29,7 +15,7 @@ class CafeDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(appBar: DetailHeader(), body: DetailBody(cafeId: cafeId));
+    return Scaffold(appBar: BaseHeader(), body: DetailBody(cafeId: cafeId));
   }
 }
 

--- a/mobile_app/lib/header.dart
+++ b/mobile_app/lib/header.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mobile_app/router/page_configuration.dart';
 
 const _titleStyle = TextStyle(
   fontSize: 12,
@@ -15,9 +16,15 @@ class _MoreActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      icon: Icon(Icons.more_vert),
-      onPressed: () {},
+      icon: Icon(Icons.info_rounded),
+      onPressed: _enterSettings(context),
     );
+  }
+
+  void Function() _enterSettings(BuildContext context) {
+    return () => Router.of(context)
+        .routerDelegate
+        .setNewRoutePath(PageConfiguration.settings);
   }
 }
 
@@ -49,7 +56,7 @@ class MainHeader extends StatelessWidget with PreferredSizeWidget {
   }
 }
 
-class DetailHeader extends StatelessWidget with PreferredSizeWidget {
+class BaseHeader extends StatelessWidget with PreferredSizeWidget {
   @override
   Size get preferredSize => Size.fromHeight(48);
 

--- a/mobile_app/lib/header.dart
+++ b/mobile_app/lib/header.dart
@@ -1,5 +1,26 @@
 import 'package:flutter/material.dart';
 
+const _titleStyle = TextStyle(
+  fontSize: 12,
+  color: Colors.black,
+);
+
+final _headerTitle =
+    Text('coffeehmm', textAlign: TextAlign.center, style: _titleStyle);
+
+const _idleIconColor = Colors.black38;
+const _activeIconColor = Color.fromRGBO(155, 218, 218, 1);
+
+class _MoreActionButton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: Icon(Icons.more_vert),
+      onPressed: () {},
+    );
+  }
+}
+
 class MainHeader extends StatelessWidget with PreferredSizeWidget {
   final void Function()? onChangeViewMode;
   final bool isTableViewMode;
@@ -14,21 +35,15 @@ class MainHeader extends StatelessWidget with PreferredSizeWidget {
     return AppBar(
       backgroundColor: isTableViewMode ? Colors.white : Colors.transparent,
       elevation: 0,
-      iconTheme: IconThemeData(color: Colors.black45),
-      title: Text('coffeehmm',
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            fontSize: 12,
-            color: Colors.black,
-          )),
+      iconTheme: IconThemeData(color: _idleIconColor),
+      title: _headerTitle,
       centerTitle: true,
-      actions: <Widget>[
+      actions: [
         IconButton(
             onPressed: onChangeViewMode,
             icon: Icon(Icons.list,
-                color: isTableViewMode
-                    ? Color.fromRGBO(155, 218, 218, 1)
-                    : Colors.black38))
+                color: isTableViewMode ? _activeIconColor : null)),
+        _MoreActionButton(),
       ],
     );
   }
@@ -43,14 +58,12 @@ class DetailHeader extends StatelessWidget with PreferredSizeWidget {
     return AppBar(
       backgroundColor: Colors.transparent,
       elevation: 0,
-      iconTheme: IconThemeData(color: Colors.black38),
-      title: Text('coffeehmm',
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            fontSize: 12,
-            color: Colors.black,
-          )),
+      iconTheme: IconThemeData(color: _idleIconColor),
+      title: _headerTitle,
       centerTitle: true,
+      actions: [
+        _MoreActionButton(),
+      ],
     );
   }
 }

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -13,11 +13,11 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  CafeModel? _selectedCafe;
+  String? _selectedCafeId;
 
   void handleCafeTapped(CafeModel cafe) {
     setState(() {
-      _selectedCafe = cafe;
+      _selectedCafeId = cafe.id;
     });
   }
 
@@ -37,14 +37,15 @@ class _MyAppState extends State<MyApp> {
             MaterialPage(
                 key: ValueKey('MainPage'),
                 child: MainScreen(onTapped: handleCafeTapped)),
-            if (_selectedCafe != null) CafeDetailPage(cafe: _selectedCafe!)
+            if (_selectedCafeId != null)
+              CafeDetailPage(cafeId: _selectedCafeId!),
           ],
           onPopPage: (route, result) {
             if (!route.didPop(result)) {
               return false;
             }
             setState(() {
-              _selectedCafe = null;
+              _selectedCafeId = null;
             });
 
             return true;

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:mobile_app/detail_page.dart';
-import 'package:mobile_app/main_page.dart';
-import 'package:mobile_app/type.dart';
+import 'package:mobile_app/router/app_route_information_parser.dart';
+import 'package:mobile_app/router/app_router_delegate.dart';
 
 void main() {
   runApp(MyApp());
@@ -13,17 +12,12 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  String? _selectedCafeId;
-
-  void handleCafeTapped(CafeModel cafe) {
-    setState(() {
-      _selectedCafeId = cafe.id;
-    });
-  }
+  final _routerDelegate = AppRouterDelegate();
+  final _routeInformationParser = AppRouteInformationParser();
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
         title: '카페 추천은, 커피흠',
         theme: new ThemeData(
           canvasColor: Colors.transparent,
@@ -32,25 +26,8 @@ class _MyAppState extends State<MyApp> {
           hoverColor: Colors.transparent,
           scaffoldBackgroundColor: Colors.white,
         ),
-        home: Navigator(
-          pages: [
-            MaterialPage(
-                key: ValueKey('MainPage'),
-                child: MainScreen(onTapped: handleCafeTapped)),
-            if (_selectedCafeId != null)
-              CafeDetailPage(cafeId: _selectedCafeId!),
-          ],
-          onPopPage: (route, result) {
-            if (!route.didPop(result)) {
-              return false;
-            }
-            setState(() {
-              _selectedCafeId = null;
-            });
-
-            return true;
-          },
-        ),
+        routerDelegate: _routerDelegate,
+        routeInformationParser: _routeInformationParser,
         debugShowCheckedModeBanner: false);
   }
 }

--- a/mobile_app/lib/main_page.dart
+++ b/mobile_app/lib/main_page.dart
@@ -8,10 +8,6 @@ import 'package:mobile_app/main_table_section.dart';
 import 'package:mobile_app/type.dart';
 
 class MainScreen extends StatefulWidget {
-  final ValueChanged<CafeModel> onTapped;
-
-  MainScreen({required this.onTapped});
-
   @override
   _MainScreenState createState() => _MainScreenState();
 }
@@ -34,31 +30,26 @@ class _MainScreenState extends State<MainScreen> {
           isTableViewMode: isTableViewMode,
           onChangeViewMode: handleViewMode,
         ),
-        body: MainBody(
-            onTapped: widget.onTapped, isTableViewMode: isTableViewMode));
+        body: MainBody(isTableViewMode: isTableViewMode));
   }
 }
 
 class MainBody extends StatefulWidget {
-  final ValueChanged<CafeModel> onTapped;
   final bool isTableViewMode;
 
-  MainBody({required this.onTapped, required this.isTableViewMode});
+  MainBody({required this.isTableViewMode});
 
   @override
-  _MainBodyState createState() => _MainBodyState(onTapped: onTapped);
+  _MainBodyState createState() => _MainBodyState();
 }
 
 class _MainBodyState extends State<MainBody> with TickerProviderStateMixin {
-  final ValueChanged<CafeModel> onTapped;
   Map<String, Future<CafeListResponse>> _cafeListResponses = {};
   Future<PlaceListResponse>? _placeResponses;
   List<PlaceModel>? _placeList;
   List<CafeModel>? _cafeList;
   CafeModel? _currentCafe;
   PlaceModel? _currentPlace;
-
-  _MainBodyState({required this.onTapped});
 
   @override
   void initState() {
@@ -119,7 +110,6 @@ class _MainBodyState extends State<MainBody> with TickerProviderStateMixin {
                           cafeList: _cafeList!,
                           currentCafe: _currentCafe!,
                           currentPlace: _currentPlace!,
-                          onTapped: onTapped,
                         )
                       : Column(children: [
                           MainSlider(
@@ -128,7 +118,6 @@ class _MainBodyState extends State<MainBody> with TickerProviderStateMixin {
                             currentCafe: _currentCafe!,
                             currentPlace: _currentPlace!,
                             onSlide: handleCafeSlide,
-                            onTapped: onTapped,
                           ),
                           MainButtonSetOfSlider()
                         ]);

--- a/mobile_app/lib/main_slider_section.dart
+++ b/mobile_app/lib/main_slider_section.dart
@@ -1,45 +1,49 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/cafe.dart';
 import 'package:mobile_app/cafe_image_slider.dart';
+import 'package:mobile_app/router/mixins/enter_cafe_detail_mixin.dart';
 import 'package:mobile_app/skeleton.dart';
 import 'package:mobile_app/type.dart';
 
-class MainSlider extends StatelessWidget {
+class MainSlider extends StatefulWidget {
   final Map<String, Future<CafeListResponse>> cafeListResponses;
   final List<CafeModel> cafeList;
   final CafeModel currentCafe;
   final PlaceModel currentPlace;
   final void Function(int) onSlide;
-  final void Function(CafeModel) onTapped;
 
   MainSlider(
       {required this.cafeListResponses,
       required this.cafeList,
       required this.currentCafe,
       required this.currentPlace,
-      required this.onSlide,
-      required this.onTapped});
+      required this.onSlide});
 
+  @override
+  _MainSliderState createState() => _MainSliderState();
+}
+
+class _MainSliderState extends State<MainSlider> with EnterCafeDetailMixin {
   @override
   Widget build(BuildContext context) {
     return Container(
         child: FutureBuilder<CafeListResponse>(
-            future: cafeListResponses[currentPlace.id],
+            future: widget.cafeListResponses[widget.currentPlace.id],
             builder: (context, snapshot) {
               if (snapshot.hasData) {
                 return GestureDetector(
                   child: Column(
                     children: [
-                      CafeInfo(cafe: currentCafe),
+                      CafeInfo(cafe: widget.currentCafe),
                       CafeImageSlider(
-                        imageList: cafeList
+                        imageList: widget.cafeList
                             .map((cafe) => cafe.image.mainImage)
                             .toList(),
-                        handleSlide: onSlide,
+                        handleSlide: widget.onSlide,
                       ),
                     ],
                   ),
-                  onTap: () => onTapped(currentCafe),
+                  onTap: enterDetail(widget.currentCafe),
                 );
               } else if (!snapshot.hasData) {
                 return Container(

--- a/mobile_app/lib/main_table_section.dart
+++ b/mobile_app/lib/main_table_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/cafe_image.dart';
+import 'package:mobile_app/router/mixins/enter_cafe_detail_mixin.dart';
 import 'package:mobile_app/skeleton.dart';
 import 'package:mobile_app/type.dart';
 import 'package:mobile_app/util.dart';
@@ -9,14 +10,12 @@ class MainTable extends StatelessWidget {
   final List<CafeModel> cafeList;
   final CafeModel currentCafe;
   final PlaceModel currentPlace;
-  final void Function(CafeModel) onTapped;
 
   MainTable(
       {required this.cafeListResponses,
       required this.cafeList,
       required this.currentCafe,
-      required this.currentPlace,
-      required this.onTapped});
+      required this.currentPlace});
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +29,7 @@ class MainTable extends StatelessWidget {
             future: cafeListResponses[currentPlace.id],
             builder: (context, snapshot) {
               if (snapshot.hasData) {
-                return MainTableCafeList(cafeList: cafes, onTapped: onTapped);
+                return MainTableCafeList(cafeList: cafes);
               } else if (snapshot.hasError) {
                 return Text("${snapshot.error}");
               }
@@ -41,9 +40,8 @@ class MainTable extends StatelessWidget {
 
 class MainTableCafeList extends StatelessWidget {
   final List<CafeModel> cafeList;
-  final void Function(CafeModel) onTapped;
 
-  MainTableCafeList({required this.cafeList, required this.onTapped});
+  MainTableCafeList({required this.cafeList});
 
   @override
   build(BuildContext context) {
@@ -51,8 +49,7 @@ class MainTableCafeList extends StatelessWidget {
         children: List.generate(
             cafeList.length,
             (index) => Column(children: [
-                  MainTableCafeElement(
-                      cafe: cafeList[index], onTapped: onTapped),
+                  MainTableCafeElement(cafe: cafeList[index]),
                   if (index < cafeList.length - 1)
                     Container(
                       height: 8,
@@ -63,12 +60,17 @@ class MainTableCafeList extends StatelessWidget {
   }
 }
 
-class MainTableCafeElement extends StatelessWidget {
+class MainTableCafeElement extends StatefulWidget {
   final CafeModel cafe;
-  final void Function(CafeModel) onTapped;
 
-  MainTableCafeElement({required this.cafe, required this.onTapped});
+  MainTableCafeElement({required this.cafe});
 
+  @override
+  _MainTableCafeElementState createState() => _MainTableCafeElementState();
+}
+
+class _MainTableCafeElementState extends State<MainTableCafeElement>
+    with EnterCafeDetailMixin {
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -86,11 +88,11 @@ class MainTableCafeElement extends StatelessWidget {
                   children: [
                     Row(
                       children: [
-                        Text(cafe.name,
+                        Text(widget.cafe.name,
                             style: TextStyle(
                                 fontSize: 15, fontWeight: FontWeight.bold)),
                         Spacer(),
-                        if (cafe.image.count > 8)
+                        if (widget.cafe.image.count > 8)
                           Text(
                             '커피흠 추천',
                             style: TextStyle(
@@ -102,7 +104,7 @@ class MainTableCafeElement extends StatelessWidget {
                     ),
                     Container(
                         margin: EdgeInsets.only(top: 4, bottom: 2),
-                        child: Text('OPEN ' + cafe.metadata.hour,
+                        child: Text('OPEN ' + widget.cafe.metadata.hour,
                             style: TextStyle(
                               fontSize: 13,
                             )))
@@ -120,21 +122,22 @@ class MainTableCafeElement extends StatelessWidget {
                           [
                             Expanded(
                                 child: CafeImage(
-                                    image: cafe.image.mainImage, size: 112)),
+                                    image: widget.cafe.image.mainImage,
+                                    size: 112)),
                             Expanded(
                                 child: CafeImage(
-                                    image: cafe.image.basicImages[0],
+                                    image: widget.cafe.image.basicImages[0],
                                     size: 112)),
                             Expanded(
                                 child: Container(
                                     child: CafeImage(
-                                        image: cafe.image.basicImages[1],
+                                        image: widget.cafe.image.basicImages[1],
                                         size: 112))),
                           ],
                           separator: SizedBox(width: 2),
                         ).toList())))
               ],
             ),
-            onTap: () => onTapped(cafe)));
+            onTap: enterDetail(widget.cafe)));
   }
 }

--- a/mobile_app/lib/router/app_route_information_parser.dart
+++ b/mobile_app/lib/router/app_route_information_parser.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/router/page_configuration.dart';
+
+class AppRouteInformationParser
+    extends RouteInformationParser<PageConfiguration> {
+  @override
+  Future<PageConfiguration> parseRouteInformation(
+      RouteInformation routeInformation) async {
+    final uri = Uri.parse(routeInformation.location ?? '/');
+
+    if (uri.pathSegments.length < 1) {
+      return PageConfiguration.home;
+    }
+
+    switch (uri.pathSegments.first) {
+      case 'cafe':
+        if (uri.pathSegments.length < 2) {
+          return PageConfiguration.home;
+        }
+
+        final cafeId = uri.pathSegments[1];
+        return PageConfiguration.cafeDetail(cafeId: cafeId);
+      case 'settings':
+        return PageConfiguration.settings;
+      default:
+        return PageConfiguration.home;
+    }
+  }
+
+  @override
+  RouteInformation restoreRouteInformation(PageConfiguration configuration) {
+    return RouteInformation(location: configuration.location);
+  }
+}

--- a/mobile_app/lib/router/app_router_delegate.dart
+++ b/mobile_app/lib/router/app_router_delegate.dart
@@ -18,14 +18,7 @@ class AppRouterDelegate extends RouterDelegate<PageConfiguration>
 
   List<MaterialPage> get pages {
     return List.unmodifiable([
-      MaterialPage(
-          child: MainScreen(
-            onTapped: (cafe) {
-              _state.enterCafeDetails(cafe.id);
-              notifyListeners();
-            },
-          ),
-          arguments: PageConfiguration.home),
+      MaterialPage(child: MainScreen(), arguments: PageConfiguration.home),
       if (_state.isOnDetailPage)
         MaterialPage(
           child: CafeDetailScreen(cafeId: _state.selectedCafeId!),

--- a/mobile_app/lib/router/app_router_delegate.dart
+++ b/mobile_app/lib/router/app_router_delegate.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/detail_page.dart';
+import 'package:mobile_app/main_page.dart';
+import 'package:mobile_app/router/app_state.dart';
+import 'package:mobile_app/router/page_configuration.dart';
+import 'package:mobile_app/router/pages.dart';
+
+class AppRouterDelegate extends RouterDelegate<PageConfiguration>
+    with ChangeNotifier, PopNavigatorRouterDelegateMixin<PageConfiguration> {
+  final GlobalKey<NavigatorState> navigatorKey;
+
+  /* App State */
+  AppState _state;
+
+  AppRouterDelegate()
+      : navigatorKey = GlobalKey(),
+        _state = AppState.initial;
+
+  List<MaterialPage> get pages {
+    return List.unmodifiable([
+      MaterialPage(
+          child: MainScreen(
+            onTapped: (cafe) {
+              _state.enterCafeDetails(cafe.id);
+              notifyListeners();
+            },
+          ),
+          arguments: PageConfiguration.home),
+      if (_state.isOnDetailPage)
+        MaterialPage(
+          child: CafeDetailScreen(cafeId: _state.selectedCafeId!),
+          arguments:
+              PageConfiguration.cafeDetail(cafeId: _state.selectedCafeId!),
+        ),
+      if (_state.isOnSettings)
+        MaterialPage(
+          child: Container(child: Center(child: Text('Settings'))),
+          arguments: PageConfiguration.settings,
+        )
+    ]);
+  }
+
+  @override
+  PageConfiguration? get currentConfiguration {
+    if (pages.isEmpty) {
+      return null;
+    }
+
+    return pages.last.arguments as PageConfiguration;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      key: navigatorKey,
+      pages: pages,
+      onPopPage: _onPopPage,
+    );
+  }
+
+  bool _onPopPage(Route<dynamic> route, dynamic result) {
+    if (!route.didPop(result)) {
+      return false;
+    }
+
+    if (_state.isOnSettings) {
+      _state.exitSettings();
+    } else if (_state.isOnDetailPage) {
+      _state.exitCafeDetails();
+    } else {
+      return false;
+    }
+
+    notifyListeners();
+
+    return true;
+  }
+
+  @override
+  Future<void> setNewRoutePath(PageConfiguration configuration) async {
+    switch (configuration.type) {
+      case Pages.cafeDetail:
+        _state.enterCafeDetails(configuration.get<String>('cafeId'));
+        notifyListeners();
+        break;
+      case Pages.settings:
+        _state.enterSettings();
+        notifyListeners();
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/mobile_app/lib/router/app_router_delegate.dart
+++ b/mobile_app/lib/router/app_router_delegate.dart
@@ -4,6 +4,7 @@ import 'package:mobile_app/main_page.dart';
 import 'package:mobile_app/router/app_state.dart';
 import 'package:mobile_app/router/page_configuration.dart';
 import 'package:mobile_app/router/pages.dart';
+import 'package:mobile_app/settings_page.dart';
 
 class AppRouterDelegate extends RouterDelegate<PageConfiguration>
     with ChangeNotifier, PopNavigatorRouterDelegateMixin<PageConfiguration> {
@@ -27,7 +28,7 @@ class AppRouterDelegate extends RouterDelegate<PageConfiguration>
         ),
       if (_state.isOnSettings)
         MaterialPage(
-          child: Container(child: Center(child: Text('Settings'))),
+          child: SettingsScreen(),
           arguments: PageConfiguration.settings,
         )
     ]);

--- a/mobile_app/lib/router/app_state.dart
+++ b/mobile_app/lib/router/app_state.dart
@@ -1,0 +1,31 @@
+class AppState {
+  String? _selectedCafeId;
+  bool _isOnSettings;
+
+  String? get selectedCafeId => _selectedCafeId;
+
+  bool get isOnDetailPage => _selectedCafeId != null;
+  bool get isOnSettings => _isOnSettings;
+
+  AppState({
+    bool? isOnSettings,
+  }) : _isOnSettings = isOnSettings ?? false;
+
+  static final initial = AppState();
+
+  void enterCafeDetails(String cafeId) {
+    _selectedCafeId = cafeId;
+  }
+
+  void exitCafeDetails() {
+    _selectedCafeId = null;
+  }
+
+  void enterSettings() {
+    _isOnSettings = true;
+  }
+
+  void exitSettings() {
+    _isOnSettings = false;
+  }
+}

--- a/mobile_app/lib/router/mixins/enter_cafe_detail_mixin.dart
+++ b/mobile_app/lib/router/mixins/enter_cafe_detail_mixin.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/router/page_configuration.dart';
+import 'package:mobile_app/type.dart';
+
+mixin EnterCafeDetailMixin<T extends StatefulWidget> on State<T> {
+  void Function() enterDetail(CafeModel cafe) {
+    return () {
+      Router.of(context)
+          .routerDelegate
+          .setNewRoutePath(PageConfiguration.cafeDetail(cafeId: cafe.id));
+    };
+  }
+}

--- a/mobile_app/lib/router/page_configuration.dart
+++ b/mobile_app/lib/router/page_configuration.dart
@@ -1,0 +1,35 @@
+import 'package:meta/meta.dart';
+import 'package:mobile_app/router/pages.dart';
+
+@immutable
+class PageConfiguration {
+  final Pages type;
+  final Map<String, dynamic> params;
+
+  PageConfiguration({required this.type, this.params = const {}});
+
+  T get<T>(String name) {
+    return params[name] as T;
+  }
+
+  String get location {
+    switch (type) {
+      case Pages.home:
+        return '/';
+      case Pages.cafeDetail:
+        final cafeId = get<String>('cafeId');
+        return '/cafe/$cafeId';
+      case Pages.settings:
+        return '/settings';
+    }
+  }
+
+  static final home = PageConfiguration(type: Pages.home);
+
+  static PageConfiguration cafeDetail({required String cafeId}) {
+    return PageConfiguration(
+        type: Pages.cafeDetail, params: {'cafeId': cafeId});
+  }
+
+  static final settings = PageConfiguration(type: Pages.settings);
+}

--- a/mobile_app/lib/router/pages.dart
+++ b/mobile_app/lib/router/pages.dart
@@ -1,0 +1,5 @@
+enum Pages {
+  home,
+  cafeDetail,
+  settings,
+}

--- a/mobile_app/lib/settings_page.dart
+++ b/mobile_app/lib/settings_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/header.dart';
+import 'package:mobile_app/util/app_stage.dart';
+import 'package:mobile_app/util/environment.dart';
 import 'package:package_info/package_info.dart';
 
 class SettingsScreen extends StatelessWidget {
@@ -31,7 +33,7 @@ class SettingsBody extends StatelessWidget {
               ),
               ListTile(
                 title: Text('앱 스테이지'),
-                subtitle: Text('dev'),
+                subtitle: Text(Environment.appStage.key),
               ),
             ],
           );

--- a/mobile_app/lib/settings_page.dart
+++ b/mobile_app/lib/settings_page.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/header.dart';
+import 'package:package_info/package_info.dart';
+
+class SettingsScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(appBar: BaseHeader(), body: SettingsBody());
+  }
+}
+
+class SettingsBody extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<PackageInfo>(
+        future: PackageInfo.fromPlatform(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return Container();
+          }
+
+          return ListView(
+            children: [
+              ListTile(
+                title: Text('앱 버전'),
+                subtitle: Text(snapshot.data!.version),
+              ),
+              ListTile(
+                title: Text('빌드 번호'),
+                subtitle: Text(snapshot.data!.buildNumber),
+              ),
+              ListTile(
+                title: Text('앱 스테이지'),
+                subtitle: Text('dev'),
+              ),
+            ],
+          );
+        });
+  }
+}

--- a/mobile_app/lib/type.dart
+++ b/mobile_app/lib/type.dart
@@ -29,6 +29,17 @@ class CafeListModel {
 }
 
 @immutable
+class SingleCafeResponse {
+  final CafeModel cafe;
+
+  SingleCafeResponse({required this.cafe});
+
+  factory SingleCafeResponse.fromJson(Map<String, dynamic> json) {
+    return SingleCafeResponse(cafe: CafeModel.fromJson(json['cafe']));
+  }
+}
+
+@immutable
 class CafeModel {
   final String id;
   final DateTime createdAt;

--- a/mobile_app/lib/util/app_stage.dart
+++ b/mobile_app/lib/util/app_stage.dart
@@ -1,0 +1,49 @@
+enum AppStage {
+  development,
+  beta,
+  release,
+}
+
+extension AppStageUtil on AppStage {
+  static final _defaultValue = AppStage.development;
+
+  static AppStage parse(String value) {
+    switch (value) {
+      case 'dev':
+      case 'development':
+      case 'DEV':
+      case 'DEVELOPMENT':
+      case 'debug':
+        return AppStage.development;
+      case 'alpha':
+      case 'beta':
+      case 'ALPHA':
+      case 'BETA':
+        return AppStage.beta;
+      case 'release':
+      case 'production':
+      case 'prod':
+      case 'RELEASE':
+      case 'PRODUCTION':
+      case 'PROD':
+        return AppStage.release;
+      default:
+        return _defaultValue;
+    }
+  }
+
+  String get key {
+    switch (this) {
+      case AppStage.development:
+        return 'dev';
+      case AppStage.beta:
+        return 'beta';
+      case AppStage.release:
+        return 'release';
+    }
+  }
+
+  bool get isLocal => this == AppStage.development;
+
+  bool get isProduction => this == AppStage.release;
+}

--- a/mobile_app/lib/util/environment.dart
+++ b/mobile_app/lib/util/environment.dart
@@ -1,0 +1,9 @@
+import 'package:mobile_app/util/app_stage.dart';
+
+class Environment {
+  static const appName =
+      String.fromEnvironment('APP_NAME', defaultValue: 'coffee hmm');
+
+  static final appStage = AppStageUtil.parse(
+      String.fromEnvironment('APP_STAGE', defaultValue: 'dev'));
+}

--- a/mobile_app/pubspec.lock
+++ b/mobile_app/pubspec.lock
@@ -184,6 +184,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0+1"
+  package_info:
+    dependency: "direct main"
+    description:
+      name: package_info
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   path:
     dependency: transitive
     description:

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   meta: ^1.3.0
   flutter_svg: ^0.22.0
   fluttertoast: ^8.0.8
+  package_info: ^2.0.2
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### 헤더에 앱 정보 액션버튼 추가
<img width="393" alt="스크린샷 2021-08-14 오후 6 25 13" src="https://user-images.githubusercontent.com/25701854/129441631-98ba6523-1c5c-4176-82e3-889cbea93580.png">

### 기본 설정 페이지
<img width="390" alt="스크린샷 2021-08-14 오후 6 24 49" src="https://user-images.githubusercontent.com/25701854/129441629-a1f78d3f-ae18-46d2-894f-b0b4c36e1648.png">
* production 환경에서는 "앱 스테이지" item 노출되지 않을 예정

### 기타 변경사항
* Detail page에서 `GET /cafe/{cafeId}` API를 **새로** 호출하도록 구현 변경
  * 이는 카페 정보를 route 기반으로 하여, 메인 페이지를 거치지 않는 상황에서도 카페를 항상 잘 가져오도록 하기 위해서 (예시로, web에서 열었을 때 browser url을 수정해서 카페 페이지에 들어갈 수 있도록 하기 위함)
  * 아래 사진처럼 url도 route 상태를 따라서 변경됨
  * deep link support 등을 염두해 두었음.
  
<img width="619" alt="스크린샷 2021-08-14 오후 6 41 48" src="https://user-images.githubusercontent.com/25701854/129441869-b32e6696-9537-4501-aab1-43b8980ab5fb.png">

* Flutter Navigator 2.0 API를 잘 활용하기 위해 패턴 변경 (RouterDelegate, RouterInformationParser 기반)
* onTapped (detail page로 들어가는 콜백) drilling을 하지 않고, Router context에서 바로 가져오도록 변경
  * 이것을 기본 제공하는 `EnterCafeDetailMixin` 구현
* PackageInfo 및 env variable 파싱 추가 (아직 실제로 스크립트에 env variable을 설정하진 않음. 따라서 항상 기본값으로 나옴)