### PR TITLE
모바일 UX 개선

### DIFF
--- a/mobile_app/lib/cafe_image.dart
+++ b/mobile_app/lib/cafe_image.dart
@@ -22,20 +22,75 @@ class CafeImage extends StatelessWidget {
       child: CachedNetworkImage(
         imageUrl: '$path$group$uri$query',
         fit: BoxFit.cover,
-        progressIndicatorBuilder: (context, url, downloadProgress) {
-          return Center(
-              child: SizedBox(
-                  width: size * 0.1,
-                  height: size * 0.1,
-                  child: CircularProgressIndicator(
-                      color: Colors.black12,
-                      strokeWidth: size > 319 ? 5 : 2,
-                      value: downloadProgress.progress)));
-        },
+        progressIndicatorBuilder: (context, url, downloadProgress) => Center(
+            child: _CafeImageProgressIndicator(
+                key: ValueKey(image.id),
+                contentSize: size,
+                progress: downloadProgress.progress ?? 0.0)),
         errorWidget: (context, error, stackTrace) {
           return Center(child: Text('no image'));
         },
       ),
     );
+  }
+}
+
+class _CafeImageProgressIndicator extends StatelessWidget {
+  static const _color = Colors.black12;
+
+  final double contentSize;
+  final double progress;
+  _CafeImageProgressIndicator(
+      {required Key key, required this.contentSize, required this.progress})
+      : super(key: key);
+
+  double get _displayedProgress => progress.clamp(0.1, 1.0);
+  double get _desiredSize => contentSize * 0.25;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+      Icon(Icons.image,
+          color: _color, size: _roundToMultipleOfFour(_desiredSize * 0.75)),
+      SizedBox(height: _roundToMultipleOfFour(_desiredSize * 0.05)),
+      _progressBar(context)
+    ]);
+  }
+
+  final _progressBarBorderRadius = BorderRadius.circular(4.0);
+
+  double get _progressBarWidth => _roundToMultipleOfFour(_desiredSize);
+  double get _progressBarHeight =>
+      _roundToMultipleOfFour(_progressBarWidth * 0.125)
+          .clamp(4.0, double.infinity);
+
+  Widget _progressBar(BuildContext context) {
+    return Container(
+        width: _progressBarWidth,
+        height: _progressBarHeight,
+        padding: const EdgeInsets.all(2.0),
+        decoration: BoxDecoration(
+            color: _color, borderRadius: _progressBarBorderRadius),
+        child: LayoutBuilder(
+            builder: (context, constraints) => Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _animatedProgress(context, maxSize: constraints.maxWidth),
+                    Spacer()
+                  ],
+                )));
+  }
+
+  Widget _animatedProgress(BuildContext context, {required double maxSize}) {
+    return AnimatedContainer(
+        decoration: BoxDecoration(
+            color: Colors.white, borderRadius: _progressBarBorderRadius),
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.ease,
+        constraints: BoxConstraints(maxWidth: maxSize * _displayedProgress));
+  }
+
+  double _roundToMultipleOfFour(double value) {
+    return (value * 0.25).roundToDouble() * 4.0;
   }
 }

--- a/mobile_app/lib/cafe_image.dart
+++ b/mobile_app/lib/cafe_image.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:mobile_app/image.dart';
 import 'package:mobile_app/type.dart';
 import 'package:mobile_app/util/environment.dart';
+import 'package:mobile_app/widgets/delayed_widget.dart';
 
 class CafeImage extends StatelessWidget {
   final CafeImageModel image;
@@ -23,10 +24,11 @@ class CafeImage extends StatelessWidget {
         imageUrl: '$path$group$uri$query',
         fit: BoxFit.cover,
         progressIndicatorBuilder: (context, url, downloadProgress) => Center(
-            child: _CafeImageProgressIndicator(
+            child: DelayedWidget(
                 key: ValueKey(image.id),
-                contentSize: size,
-                progress: downloadProgress.progress ?? 0.0)),
+                child: _CafeImageProgressIndicator(
+                    contentSize: size,
+                    progress: downloadProgress.progress ?? 0.0))),
         errorWidget: (context, error, stackTrace) {
           return Center(child: Text('no image'));
         },
@@ -41,8 +43,7 @@ class _CafeImageProgressIndicator extends StatelessWidget {
   final double contentSize;
   final double progress;
   _CafeImageProgressIndicator(
-      {required Key key, required this.contentSize, required this.progress})
-      : super(key: key);
+      {required this.contentSize, required this.progress});
 
   double get _displayedProgress => progress.clamp(0.1, 1.0);
   double get _desiredSize => contentSize * 0.25;

--- a/mobile_app/lib/cafe_image.dart
+++ b/mobile_app/lib/cafe_image.dart
@@ -4,6 +4,7 @@ import 'package:mobile_app/image.dart';
 import 'package:mobile_app/type.dart';
 import 'package:mobile_app/util/environment.dart';
 import 'package:mobile_app/widgets/delayed_widget.dart';
+import 'package:mobile_app/widgets/image_progress_indicator.dart';
 
 class CafeImage extends StatelessWidget {
   final CafeImageModel image;
@@ -26,7 +27,7 @@ class CafeImage extends StatelessWidget {
         progressIndicatorBuilder: (context, url, downloadProgress) => Center(
             child: DelayedWidget(
                 key: ValueKey(image.id),
-                child: _CafeImageProgressIndicator(
+                child: ImageProgressIndicator(
                     contentSize: size,
                     progress: downloadProgress.progress ?? 0.0))),
         errorWidget: (context, error, stackTrace) {
@@ -34,64 +35,5 @@ class CafeImage extends StatelessWidget {
         },
       ),
     );
-  }
-}
-
-class _CafeImageProgressIndicator extends StatelessWidget {
-  static const _color = Colors.black12;
-
-  final double contentSize;
-  final double progress;
-  _CafeImageProgressIndicator(
-      {required this.contentSize, required this.progress});
-
-  double get _displayedProgress => progress.clamp(0.1, 1.0);
-  double get _desiredSize => contentSize * 0.25;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-      Icon(Icons.image,
-          color: _color, size: _roundToMultipleOfFour(_desiredSize * 0.75)),
-      SizedBox(height: _roundToMultipleOfFour(_desiredSize * 0.05)),
-      _progressBar(context)
-    ]);
-  }
-
-  final _progressBarBorderRadius = BorderRadius.circular(4.0);
-
-  double get _progressBarWidth => _roundToMultipleOfFour(_desiredSize);
-  double get _progressBarHeight =>
-      _roundToMultipleOfFour(_progressBarWidth * 0.125)
-          .clamp(4.0, double.infinity);
-
-  Widget _progressBar(BuildContext context) {
-    return Container(
-        width: _progressBarWidth,
-        height: _progressBarHeight,
-        padding: const EdgeInsets.all(2.0),
-        decoration: BoxDecoration(
-            color: _color, borderRadius: _progressBarBorderRadius),
-        child: LayoutBuilder(
-            builder: (context, constraints) => Row(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    _animatedProgress(context, maxSize: constraints.maxWidth),
-                    Spacer()
-                  ],
-                )));
-  }
-
-  Widget _animatedProgress(BuildContext context, {required double maxSize}) {
-    return AnimatedContainer(
-        decoration: BoxDecoration(
-            color: Colors.white, borderRadius: _progressBarBorderRadius),
-        duration: const Duration(milliseconds: 150),
-        curve: Curves.ease,
-        constraints: BoxConstraints(maxWidth: maxSize * _displayedProgress));
-  }
-
-  double _roundToMultipleOfFour(double value) {
-    return (value * 0.25).roundToDouble() * 4.0;
   }
 }

--- a/mobile_app/lib/header.dart
+++ b/mobile_app/lib/header.dart
@@ -8,8 +8,7 @@ mixin _HeaderSpec on StatelessWidget {
       textAlign: TextAlign.center,
       style: TextStyle(fontSize: 13, color: Colors.black87));
 
-  final _idleIconColor = Colors.black38;
-  final _activeIconColor = Color.fromRGBO(242, 196, 109, 1);
+  final _iconColor = Colors.black38;
 
   bool get _showMoreAction {
     return Environment.appStage == AppStage.development;
@@ -46,14 +45,13 @@ class MainHeader extends StatelessWidget with PreferredSizeWidget, _HeaderSpec {
     return AppBar(
       backgroundColor: isTableViewMode ? Colors.white : Colors.transparent,
       elevation: 0,
-      iconTheme: IconThemeData(color: _idleIconColor),
+      iconTheme: IconThemeData(color: _iconColor),
       title: _headerTitle,
       centerTitle: true,
       actions: [
         IconButton(
             onPressed: onChangeViewMode,
-            icon: Icon(Icons.list,
-                color: isTableViewMode ? _activeIconColor : null)),
+            icon: Icon(isTableViewMode ? Icons.grid_view_sharp : Icons.list)),
         if (_showMoreAction) _MoreActionButton(),
       ],
     );
@@ -69,7 +67,7 @@ class BaseHeader extends StatelessWidget with PreferredSizeWidget, _HeaderSpec {
     return AppBar(
       backgroundColor: Colors.transparent,
       elevation: 0,
-      iconTheme: IconThemeData(color: _idleIconColor),
+      iconTheme: IconThemeData(color: _iconColor),
       title: _headerTitle,
       centerTitle: true,
       actions: [

--- a/mobile_app/lib/header.dart
+++ b/mobile_app/lib/header.dart
@@ -1,16 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/router/page_configuration.dart';
+import 'package:mobile_app/util/app_stage.dart';
+import 'package:mobile_app/util/environment.dart';
 
-const _titleStyle = TextStyle(
-  fontSize: 13,
-  color: Colors.black87,
-);
+mixin _HeaderSpec on StatelessWidget {
+  final _headerTitle = Text('coffee hmm',
+      textAlign: TextAlign.center,
+      style: TextStyle(fontSize: 13, color: Colors.black87));
 
-final _headerTitle =
-    Text('coffee hmm', textAlign: TextAlign.center, style: _titleStyle);
+  final _idleIconColor = Colors.black38;
+  final _activeIconColor = Color.fromRGBO(242, 196, 109, 1);
 
-const _idleIconColor = Colors.black38;
-const _activeIconColor = Color.fromRGBO(242, 196, 109, 1);
+  bool get _showMoreAction {
+    return Environment.appStage == AppStage.development;
+  }
+}
 
 class _MoreActionButton extends StatelessWidget {
   @override
@@ -28,7 +32,7 @@ class _MoreActionButton extends StatelessWidget {
   }
 }
 
-class MainHeader extends StatelessWidget with PreferredSizeWidget {
+class MainHeader extends StatelessWidget with PreferredSizeWidget, _HeaderSpec {
   final void Function()? onChangeViewMode;
   final bool isTableViewMode;
 
@@ -50,13 +54,13 @@ class MainHeader extends StatelessWidget with PreferredSizeWidget {
             onPressed: onChangeViewMode,
             icon: Icon(Icons.list,
                 color: isTableViewMode ? _activeIconColor : null)),
-        _MoreActionButton(),
+        if (_showMoreAction) _MoreActionButton(),
       ],
     );
   }
 }
 
-class BaseHeader extends StatelessWidget with PreferredSizeWidget {
+class BaseHeader extends StatelessWidget with PreferredSizeWidget, _HeaderSpec {
   @override
   Size get preferredSize => Size.fromHeight(52);
 
@@ -69,7 +73,7 @@ class BaseHeader extends StatelessWidget with PreferredSizeWidget {
       title: _headerTitle,
       centerTitle: true,
       actions: [
-        _MoreActionButton(),
+        if (_showMoreAction) _MoreActionButton(),
       ],
     );
   }

--- a/mobile_app/lib/main_bottom_sheet.dart
+++ b/mobile_app/lib/main_bottom_sheet.dart
@@ -154,6 +154,7 @@ class RepresentativeCafe extends StatelessWidget {
       children: [
         Card(
             clipBehavior: Clip.antiAlias,
+            elevation: 0,
             margin: EdgeInsets.only(right: 3),
             child: Container(
               width: 100,

--- a/mobile_app/lib/widgets/delayed_widget.dart
+++ b/mobile_app/lib/widgets/delayed_widget.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+class DelayedWidget extends StatefulWidget {
+  final Widget child;
+  final Duration delay;
+  const DelayedWidget(
+      {Key? key,
+      required this.child,
+      this.delay = const Duration(milliseconds: 500)})
+      : super(key: key);
+
+  @override
+  _DelayedWidgetState createState() => _DelayedWidgetState();
+}
+
+class _DelayedWidgetState extends State<DelayedWidget> {
+  bool _show = false;
+  late Timer _timer;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _timer = Timer(
+        widget.delay,
+        () => setState(() {
+              _show = true;
+            }));
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+
+    _timer.cancel();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      opacity: _show ? 1.0 : 0.0,
+      duration: const Duration(milliseconds: 150),
+      child: widget.child,
+    );
+  }
+}

--- a/mobile_app/lib/widgets/image_progress_indicator.dart
+++ b/mobile_app/lib/widgets/image_progress_indicator.dart
@@ -1,36 +1,50 @@
 import 'package:flutter/material.dart';
 
+@immutable
+class _ImageProgressIndicatorDimension {
+  final double contentSize;
+  _ImageProgressIndicatorDimension({required this.contentSize});
+
+  double get desiredSize => contentSize * 0.25;
+  double get iconSize => _roundToMultipleOfFour(desiredSize * 0.825);
+  double get gapSize => _roundToMultipleOfFour(desiredSize * 0.05);
+  double get progressBarWidth => _roundToMultipleOfFour(desiredSize);
+  double get progressBarHeight =>
+      _roundToMultipleOfFour(desiredSize * 0.125).clamp(4.0, double.infinity);
+
+  double _roundToMultipleOfFour(double value) {
+    return (value * 0.25).roundToDouble() * 4.0;
+  }
+}
+
 class ImageProgressIndicator extends StatelessWidget {
   static const _color = Colors.black12;
 
   final double contentSize;
   final double progress;
-  ImageProgressIndicator({required this.contentSize, required this.progress});
+
+  final _ImageProgressIndicatorDimension _dimension;
+
+  ImageProgressIndicator({required this.contentSize, required this.progress})
+      : _dimension = _ImageProgressIndicatorDimension(contentSize: contentSize);
 
   double get _displayedProgress => progress.clamp(0.1, 1.0);
-  double get _desiredSize => contentSize * 0.25;
 
   @override
   Widget build(BuildContext context) {
     return Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-      Icon(Icons.image,
-          color: _color, size: _roundToMultipleOfFour(_desiredSize * 0.75)),
-      SizedBox(height: _roundToMultipleOfFour(_desiredSize * 0.05)),
+      Icon(Icons.image, color: _color, size: _dimension.iconSize),
+      SizedBox(height: _dimension.gapSize),
       _progressBar(context)
     ]);
   }
 
   final _progressBarBorderRadius = BorderRadius.circular(4.0);
 
-  double get _progressBarWidth => _roundToMultipleOfFour(_desiredSize);
-  double get _progressBarHeight =>
-      _roundToMultipleOfFour(_progressBarWidth * 0.125)
-          .clamp(4.0, double.infinity);
-
   Widget _progressBar(BuildContext context) {
     return Container(
-        width: _progressBarWidth,
-        height: _progressBarHeight,
+        width: _dimension.progressBarWidth,
+        height: _dimension.progressBarHeight,
         padding: const EdgeInsets.all(2.0),
         decoration: BoxDecoration(
             color: _color, borderRadius: _progressBarBorderRadius),
@@ -51,9 +65,5 @@ class ImageProgressIndicator extends StatelessWidget {
         duration: const Duration(milliseconds: 150),
         curve: Curves.ease,
         constraints: BoxConstraints(maxWidth: maxSize * _displayedProgress));
-  }
-
-  double _roundToMultipleOfFour(double value) {
-    return (value * 0.25).roundToDouble() * 4.0;
   }
 }

--- a/mobile_app/lib/widgets/image_progress_indicator.dart
+++ b/mobile_app/lib/widgets/image_progress_indicator.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+class ImageProgressIndicator extends StatelessWidget {
+  static const _color = Colors.black12;
+
+  final double contentSize;
+  final double progress;
+  ImageProgressIndicator({required this.contentSize, required this.progress});
+
+  double get _displayedProgress => progress.clamp(0.1, 1.0);
+  double get _desiredSize => contentSize * 0.25;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+      Icon(Icons.image,
+          color: _color, size: _roundToMultipleOfFour(_desiredSize * 0.75)),
+      SizedBox(height: _roundToMultipleOfFour(_desiredSize * 0.05)),
+      _progressBar(context)
+    ]);
+  }
+
+  final _progressBarBorderRadius = BorderRadius.circular(4.0);
+
+  double get _progressBarWidth => _roundToMultipleOfFour(_desiredSize);
+  double get _progressBarHeight =>
+      _roundToMultipleOfFour(_progressBarWidth * 0.125)
+          .clamp(4.0, double.infinity);
+
+  Widget _progressBar(BuildContext context) {
+    return Container(
+        width: _progressBarWidth,
+        height: _progressBarHeight,
+        padding: const EdgeInsets.all(2.0),
+        decoration: BoxDecoration(
+            color: _color, borderRadius: _progressBarBorderRadius),
+        child: LayoutBuilder(
+            builder: (context, constraints) => Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _animatedProgress(context, maxSize: constraints.maxWidth),
+                    Spacer()
+                  ],
+                )));
+  }
+
+  Widget _animatedProgress(BuildContext context, {required double maxSize}) {
+    return AnimatedContainer(
+        decoration: BoxDecoration(
+            color: Colors.white, borderRadius: _progressBarBorderRadius),
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.ease,
+        constraints: BoxConstraints(maxWidth: maxSize * _displayedProgress));
+  }
+
+  double _roundToMultipleOfFour(double value) {
+    return (value * 0.25).roundToDouble() * 4.0;
+  }
+}

--- a/mobile_app/lib/widgets/image_progress_indicator.dart
+++ b/mobile_app/lib/widgets/image_progress_indicator.dart
@@ -5,7 +5,7 @@ class _ImageProgressIndicatorDimension {
   final double contentSize;
   _ImageProgressIndicatorDimension({required this.contentSize});
 
-  double get desiredSize => contentSize * 0.25;
+  double get desiredSize => (contentSize * 0.25).clamp(0, 64.0);
   double get iconSize => _roundToMultipleOfFour(desiredSize * 0.825);
   double get gapSize => _roundToMultipleOfFour(desiredSize * 0.05);
   double get progressBarWidth => _roundToMultipleOfFour(desiredSize);


### PR DESCRIPTION
- 디자인 피드백: 핫플레이스 카페 리스트에서 이미지 elevation (그림자) 삭제
- UX 피드백: 설정 페이지를 `stage=developement`일 때만 표시
- 디자인 피드백: 헤더 테이블뷰 아이콘 교체 (on/off에서 icon toggle로 변경)
- UX 피드백: image progress indicator가 너무 자주 보이는 점 수정
  - 애니메이션을 덜 시선을 끄는 progress bar 형태로 조정
  - 500ms 이후에도 이미지가 로딩되지 않았을 때만 progress indicator가 보이도록 함