### PR TITLE
Revert "GET /cafe/list, GET /cafe/feed에서 메인 이미지만 내려주도록 수정 (#210)"

### DIFF
--- a/services/http-api/README.md
+++ b/services/http-api/README.md
@@ -155,7 +155,6 @@ To clarify:
 Retrieves a list of cafe as a feed, which is selected randomly (for now), among the list of cafes.
 
 - The list of cafes is **fixed** per user, and per day. Unsigned users will retrieve different result per request.
-- Only images with `isMain: true` will be supplied with this endpoint. `cafe.list[i].image.count` will contain total number of active images of cafe. However, `cafe.list[i].image.list` will contain **at most one image**.
 
 **Query Parameters**
 
@@ -209,6 +208,19 @@ Retrieves a list of cafe as a feed, which is selected randomly (for now), among 
                 "tag": "입구",
                 "width": 1024,
                 "height": 1920
+              }
+              "relativeUri": "/images/11111111-1111-1111-1111-111111111111",
+              "state": "active"
+            },
+            {
+              "id": "11111111-1111-1111-1111-111111111111",
+              "createdAt": "2020-01-01T00:00:00.000Z",
+              "updatedAt": "2020-01-01T00:00:00.000Z",
+              "cafeId": "11111111-1111-1111-1111-111111111111",
+              "index": 1,
+              "isMain": false,
+              "metadata": {
+                "tag": "메뉴"
               }
               "relativeUri": "/images/11111111-1111-1111-1111-111111111111",
               "state": "active"
@@ -290,8 +302,6 @@ Retrieve the number of cafes.
 
 Retrieve a list of cafes.
 
-- Only images with `isMain: true` will be supplied with this endpoint. `cafe.list[i].image.count` will contain total number of images of cafe (including number of hidden cafe images, depending on `showHiddenImages` query parameter). However, `cafe.list[i].image.list` will contain **at most one image**.
-
 **Query Parameters**
 
 | **Name**           | **Type**                                                     | **Required?**                 | **Description**                                                                                                                                                                                                                     |
@@ -347,6 +357,19 @@ Retrieve a list of cafes.
                 "tag": "입구",
                 "width": 1024,
                 "height": 1920
+              }
+              "relativeUri": "/images/11111111-1111-1111-1111-111111111111",
+              "state": "active"
+            },
+            {
+              "id": "11111111-1111-1111-1111-111111111111",
+              "createdAt": "2020-01-01T00:00:00.000Z",
+              "updatedAt": "2020-01-01T00:00:00.000Z",
+              "cafeId": "11111111-1111-1111-1111-111111111111",
+              "index": 1,
+              "isMain": false,
+              "metadata": {
+                "tag": "메뉴"
               }
               "relativeUri": "/images/11111111-1111-1111-1111-111111111111",
               "state": "active"

--- a/services/http-api/src/routes/cafe/cafe.control.ts
+++ b/services/http-api/src/routes/cafe/cafe.control.ts
@@ -206,7 +206,6 @@ export const getFeed = handler<
       .select()
       .where({
         fkCafeId: In(cafes.map((cafe) => cafe.id)),
-        isMain: true,
         state: Not(In([CafeImageState.hidden, CafeImageState.deleted])),
       })
       .orderBy({ index: 'ASC' })
@@ -538,7 +537,6 @@ export const getList = handler<
       .select()
       .where({
         fkCafeId: In(cafes.map((cafe) => cafe.id)),
-        isMain: true,
         state: Not(
           In([
             ...(showHiddenImages ? [] : [CafeImageState.hidden]),


### PR DESCRIPTION
This reverts commit 64b9846f3fe91bdb6c2288642627ee69c68ea123.

테이블뷰 기획사항 누락으로 해당 수정 적용 불가능. (#206 참조)