### PR TITLE
feat: 상세 페이지 통합검색 영역 분리

### DIFF
--- a/mobile_app/lib/constants/color.dart
+++ b/mobile_app/lib/constants/color.dart
@@ -23,6 +23,7 @@ class Palette {
   static const lightBlue = Color.fromRGBO(222, 237, 255, 1.0);
 
   /*Green*/
+  static const green = Color.fromRGBO(56, 122, 63, 1);
   static const lightGreen = Color.fromRGBO(201, 242, 215, 1);
   
   /*Purple*/

--- a/mobile_app/lib/constants/color.dart
+++ b/mobile_app/lib/constants/color.dart
@@ -1,23 +1,30 @@
 import 'package:flutter/material.dart';
 
 class Palette {
-  static final highlightedColor = Color.fromRGBO(40, 110, 240, 1.0);
+  static const highlightedColor = Color.fromRGBO(40, 110, 240, 1.0);
 
   /*Background*/
-  static final grayBG = Color.fromRGBO(242, 242, 242, 1.0);
-  static final whiteTransparentBG = Color.fromRGBO(255, 255, 255, 0.9);
-  static final blueBG = Color.fromRGBO(77, 135, 243, 1.0);
+  static const grayBG = Color.fromRGBO(242, 242, 242, 1.0);
+  static const whiteTransparentBG = Color.fromRGBO(255, 255, 255, 0.9);
+  static const blueBG = Color.fromRGBO(77, 135, 243, 1.0);
 
   /*Gray*/
-  static final darkGray = Color.fromRGBO(30, 30, 30, 1.0);
-  static final gray = Color.fromRGBO(166, 166, 166, 1.0);
-  static final lightGray = Color.fromRGBO(240, 240, 240, 1.0);
+  static const darkGray = Color.fromRGBO(30, 30, 30, 1.0);
+  static const gray = Color.fromRGBO(166, 166, 166, 1.0);
+  static const lightGray = Color.fromRGBO(240, 240, 240, 1.0);
 
   /*Red*/
-  static final lightRed = Color.fromRGBO(255, 136, 136, 1.0);
+  static const red = Color.fromRGBO(242, 82, 82, 1.0);
+  static const lightRed = Color.fromRGBO(255, 136, 136, 1.0);
 
   /*Blue*/
-  static final darkBlue = Color.fromRGBO(2, 21, 38, 1.0);
-  static final blue =  Color.fromRGBO(40, 110, 240, 1.0);
-  static final lightBlue = Color.fromRGBO(222, 237, 255, 1.0);
+  static const darkBlue = Color.fromRGBO(2, 21, 38, 1.0);
+  static const blue =  Color.fromRGBO(40, 110, 240, 1.0);
+  static const lightBlue = Color.fromRGBO(222, 237, 255, 1.0);
+
+  /*Green*/
+  static const lightGreen = Color.fromRGBO(201, 242, 215, 1);
+  
+  /*Purple*/
+  static const lightPurple = Color.fromRGBO(228, 206, 242, 1);
 }

--- a/mobile_app/lib/constants/type.dart
+++ b/mobile_app/lib/constants/type.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:mobile_app/util/type_transformer.dart';
+import 'package:mobile_app/util/time_formatter.dart';
 
 import 'enum.dart';
 
@@ -142,13 +143,13 @@ class CafeImageModel {
 
 @immutable
 class CafeImageMetadataModel {
-  final String tag;
+  final String? tag;
 
-  CafeImageMetadataModel({required this.tag});
+  CafeImageMetadataModel({this.tag});
 
-  factory CafeImageMetadataModel.fromJson(Map<String, dynamic> json) {
+  factory CafeImageMetadataModel.fromJson(Map<String, dynamic>? json) {
     return CafeImageMetadataModel(
-      tag: json['tag'],
+      tag: json?['tag'],
     );
   }
 }
@@ -286,15 +287,32 @@ class CafeMetaSubwayModel {
 }
 
 @immutable
-class CafeMetaHoursModel {
-  final String? weekday;
-  final String? weekend;
+class CafeMetaOperationHoursModel {
+  final DateTime open;
+  final DateTime close;
 
-  CafeMetaHoursModel({this.weekday, this.weekend});
+  CafeMetaOperationHoursModel({required this.open, required this.close});
+}
+
+@immutable
+class CafeMetaHoursModel {
+  final CafeMetaOperationHoursModel? weekday;
+  final CafeMetaOperationHoursModel? weekend;
+  final String? weekdayStr;
+  final String? weekendStr;
+
+  CafeMetaHoursModel({this.weekday, this.weekend, this.weekdayStr, this.weekendStr});
 
   factory CafeMetaHoursModel.fromJson(Map<String, dynamic>? json) {
+    final String? jsonWeekday = json?['weekday'];
+    final String? jsonWeekend = json?['weekend'];
+
     return CafeMetaHoursModel(
-        weekday: json?['weekday'], weekend: json?['weekend']);
+      weekday: jsonWeekday?.createOperationHours(),
+      weekend: jsonWeekend?.createOperationHours(),
+      weekdayStr: jsonWeekday,
+      weekendStr: jsonWeekend,
+    );
   }
 }
 

--- a/mobile_app/lib/util/cafe_detail.dart
+++ b/mobile_app/lib/util/cafe_detail.dart
@@ -10,19 +10,21 @@ dynamic getCafeMetadataPlainText(dynamic data) {
 }
 
 String? getCafeMetadataHours(CafeMetaHoursModel? hours) {
-  final weekday = hours?.weekday;
-  final weekend = hours?.weekend;
+  final _weekday = hours?.weekday;
+  final _weekend = hours?.weekend;
+  final _weekdayStr = hours?.weekdayStr;
+  final _weekendStr = hours?.weekendStr;
 
-  if (weekday == null && weekend == null) return null;
+  if (_weekday == null && _weekend == null) return null;
 
-  if (weekday == weekend) {
-    return '평일/주말 $weekday';
+  if (_weekday?.close == _weekend?.close && _weekday?.open == _weekend?.open) {
+    return '평일/주말 $_weekdayStr';
   }
 
-  final _weekday = hasCafeMetadata(weekday) ? '평일 $weekday ' : '';
-  final _weekend = hasCafeMetadata(weekend) ? '주말 $weekend' : '';
+  final _weekdayMeta = hasCafeMetadata(_weekdayStr) ? '평일 $_weekdayStr ' : '';
+  final _weekendMeta = hasCafeMetadata(_weekendStr) ? '주말 $_weekendStr' : '';
 
-  return '$_weekday$_weekend';
+  return '$_weekdayMeta$_weekendMeta';
 }
 
 CafeDetailInfoModel getCafeDetailInfo(CafeModel cafe) {

--- a/mobile_app/lib/util/time_formatter.dart
+++ b/mobile_app/lib/util/time_formatter.dart
@@ -1,0 +1,18 @@
+import 'package:mobile_app/constants/type.dart';
+
+extension TimeFormatter on String {
+  CafeMetaOperationHoursModel? createOperationHours(){
+    final List<String> _operationHours = this.split(' ~ ');
+
+    if(_operationHours.length < 2 ) return null;
+
+    return CafeMetaOperationHoursModel(
+      open: _operationHours[0].stringToDateTime(),
+      close: _operationHours[1].stringToDateTime(),
+    );
+  }
+
+  DateTime stringToDateTime(){
+    return DateTime.parse('0000-00-00T' + this);
+  }
+}

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_body_content.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_body_content.dart
@@ -4,11 +4,12 @@ import 'package:mobile_app/util/cafe_detail.dart';
 import 'package:mobile_app/view/cafe_detail/cafe_detail_footer.dart';
 import 'package:mobile_app/view/cafe_detail/cafe_detail_info.dart';
 import 'package:mobile_app/view/cafe_detail/cafe_detail_location.dart';
+import 'package:mobile_app/view/cafe_detail/cafe_detail_media_search.dart';
 import 'package:mobile_app/view/cafe_detail/cafe_detail_menu.dart';
 import 'package:mobile_app/view/common/cafe_image_slider.dart';
 import 'package:mobile_app/view/common/image_index_bullet.dart';
 
-const double _footerHeight = 72;
+const double _footerHeight = 80;
 
 class DetailBodyContent extends StatefulWidget {
   final CafeModel cafe;
@@ -27,6 +28,7 @@ class _DetailBodyContentState extends State<DetailBodyContent> {
   bool get _hasLocation => hasCafeMetadata(cafe.metadata?.location?.lat) &&
   hasCafeMetadata(cafe.metadata?.location?.lng);
   bool get _hasMenus => (cafe.metadata?.mainMenus ?? []).length > 0;
+  bool get _hasMetadata => _hasLocation || _hasMenus;
   double footerOffset = 0;
   int? _currentIndex;
 
@@ -35,7 +37,7 @@ class _DetailBodyContentState extends State<DetailBodyContent> {
   @override
   void initState(){
     super.initState();
-    footerOffset = (_hasLocation || _hasMenus) ? -_footerHeight : 0;
+    footerOffset = _hasMetadata ? -_footerHeight : -2;
   }
 
   void _handleImageSlide(int index) {
@@ -59,6 +61,8 @@ class _DetailBodyContentState extends State<DetailBodyContent> {
     _handleScroll(mapKey);
   }
   void _handleFooterOffset(double scrollDelta, double offset){
+    if(!_hasMetadata) return;
+
     setState(() {
         if(offset < _footerHeight){
           footerOffset = offset - _footerHeight;

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_body_content.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_body_content.dart
@@ -108,6 +108,7 @@ class _DetailBodyContentState extends State<DetailBodyContent> {
                     key: menuKey,
                     child: CafeDetailMenus(menus: cafe.metadata!.mainMenus!),
                   ),
+                CafeDetailMediaSearch(cafeName: cafe.name),
                 SizedBox(height: 100),
               ],
             ),

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_info.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_info.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/constants/type.dart';
 import 'package:mobile_app/util/cafe_detail.dart';
-import 'package:mobile_app/util/common.dart';
+import 'package:mobile_app/view/cafe_detail/cafe_detail_info_time_item.dart';
 import 'package:mobile_app/view/common/cafe_info_item.dart';
 import 'package:mobile_app/view/common/cafe_name.dart';
 
@@ -28,49 +28,33 @@ class CafeDetailInfo extends StatelessWidget {
   }
 
   Widget _buildCafeDetailInfo(BuildContext context) {
-    final data = getCafeDetailInfo(cafe);
+    final _data = getCafeDetailInfo(cafe);
+    final _hasMetadata = hasCafeMetadata(_data.hour)
+    || (hasCafeMetadata(_data.line) && hasCafeMetadata(_data.station))
+    || hasCafeMetadata(_data.call)
+    || hasCafeMetadata(_data.address);
 
     return Column(
       children: [
-        if (hasCafeMetadata(data.hour))
+        if (hasCafeMetadata(_data.hour))
+          CafeDetailInfoTimeItem(displayTime: _data.hour, hours: cafe.metadata!.hours!),
+        if (hasCafeMetadata(_data.line) && hasCafeMetadata(_data.station))
+          CafeDetailSubwayLineItem(station: _data.station, line: _data.line),
+        if (hasCafeMetadata(_data.call))
           CafeInfoItem(
-            text: data.hour,
-            fontSize: 14,
-            icon: Icons.access_time_rounded,
-            margin: EdgeInsets.only(bottom: 18),
-          ),
-        if (hasCafeMetadata(data.address))
-          CafeInfoItem(
-            text: data.address,
-            fontSize: 14,
-            icon: Icons.place_rounded,
-            margin: EdgeInsets.only(bottom: 18),
-          ),
-        if (hasCafeMetadata(data.line) && hasCafeMetadata(data.station))
-          CafeDetailSubwayLineItem(station: data.station, line: data.line),
-        if (hasCafeMetadata(data.call))
-          CafeInfoItem(
-            text: data.call,
+            text: _data.call,
             fontSize: 14,
             icon: Icons.call,
             margin: EdgeInsets.only(bottom: 18),
           ),
-        CafeInfoItem(
-          text: '네이버 통합검색 바로가기',
-          icon: Icons.search_rounded,
-          fontSize: 14,
-          subIcon: Icons.launch_rounded,
-          onPressed: () =>
-              handleNaverClick(cafe.name + ' ' + cafe.place.name, context),
-          margin: EdgeInsets.only(bottom: 18),
-        ),
-        CafeInfoItem(
-          text: '인스타그램 태그검색 바로가기',
-          fontSize: 14,
-          icon: Icons.search_rounded,
-          subIcon: Icons.launch_rounded,
-          onPressed: () => handleInstagramClick(cafe.name, context),
-        )
+        if (hasCafeMetadata(_data.address))
+          CafeInfoItem(
+            text: _data.address,
+            fontSize: 14,
+            icon: Icons.place_rounded,
+          ),
+        if(!_hasMetadata)
+          Text('곧 업데이트 됩니다 !')
       ],
     );
   }

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_info_subway_item.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_info_subway_item.dart
@@ -13,7 +13,7 @@ class CafeDetailSubwayLineItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: EdgeInsets.only(bottom: 12),
+      margin: EdgeInsets.only(bottom: 18),
       child: Row(
         children: [
           Icon(Icons.directions_subway, size: 15, color: Palette.highlightedColor),

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_info_time_item.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_info_time_item.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/constants/color.dart';
+import 'package:mobile_app/constants/type.dart';
+import 'package:mobile_app/view/common/cafe_operation_status.dart';
+
+class CafeDetailInfoTimeItem extends StatelessWidget with CafeOperationStatus {
+  final String displayTime;
+  final CafeMetaHoursModel hours;
+
+  CafeDetailInfoTimeItem({ required this.displayTime, required this.hours });
+
+  @override
+  Widget build(BuildContext context){
+    final int _today = DateTime.now().weekday;
+    final CafeMetaOperationHoursModel? _operationHours = _today < 6 ?  hours.weekday : hours.weekend;
+    final String? _operationStatus = getCafeOperationStatus(_operationHours);
+    
+    return  Container(
+      margin: EdgeInsets.only(bottom: 18),
+      child: Row(
+        children: [
+          Icon(
+            Icons.access_time_rounded,
+            size: 15,
+            color: Palette.highlightedColor,
+          ),
+          SizedBox(width: 6),
+          if(_operationStatus != null )
+            Row(
+              children: [
+                Text(_operationStatus,
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: _operationStatus == open ? Palette.green : Palette.gray,
+                    )
+                ),
+                SizedBox(width: 4),
+                Text(String.fromCharCode(0X2022),
+                    style: TextStyle(color: Palette.gray)
+                ),
+                SizedBox(width: 4),
+              ],
+            ),
+          Text(displayTime),
+        ],
+      ),
+    );
+  }
+}
+
+
+
+

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_list_item.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_list_item.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/constants/color.dart';
+
+class CafeDetailListItem extends StatelessWidget {
+  final String title;
+  final IconData icon;
+  final Color color;
+  final IconData? subIcon;
+  final Function()? onPressed;
+
+  CafeDetailListItem({
+    required this.title,
+    required this.icon,
+    this.color = Palette.lightBlue,
+    this.subIcon,
+    this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context){
+    return ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          primary: Colors.transparent,
+          shadowColor: Colors.transparent,
+          padding: EdgeInsets.all(0),
+        ),
+        onPressed: onPressed,
+        child: Container(
+            padding: EdgeInsets.only(bottom: 20, left: 20),
+            color: Colors.white,
+            child: Row(
+              children: [
+                Container(
+                  width: 48,
+                  height: 48,
+                  decoration: BoxDecoration(
+                      color: color,
+                      borderRadius: BorderRadius.all(Radius.circular(18))
+                  ),
+                  child: Icon(icon, size: 28, color: Colors.white),
+                ),
+                SizedBox(width: 12),
+                Text(title,
+                    style: TextStyle(
+                        color: Palette.darkGray,
+                        fontSize: 14,
+                        fontWeight: FontWeight.bold
+                    )
+                ),
+                if (subIcon != null)
+                  Row(
+                    children: [SizedBox(width: 6), Icon(subIcon, size: 14, color: Colors.black)],
+                  )
+              ],
+            )
+        ),
+    );
+  }
+}

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_location.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_location.dart
@@ -23,7 +23,7 @@ class CafeDetailLocation extends StatelessWidget {
                     double.parse(cafe.metadata!.location!.lat!),
                     double.parse(cafe.metadata!.location!.lng!)),
                 title: cafe.name,
-                height: 220)
+                height: 300)
           ],
        )
     );

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_media_search.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_media_search.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:mobile_app/constants/color.dart';
+import 'package:mobile_app/util/common.dart';
+import 'package:mobile_app/view/cafe_detail/cafe_detail_list_item.dart';
+import 'package:mobile_app/view/cafe_detail/cafe_detail_section_title.dart';
+
+class CafeDetailMediaSearch extends StatelessWidget {
+  final String cafeName;
+
+  CafeDetailMediaSearch({required this.cafeName});
+
+  @override
+  Widget build(BuildContext context){
+    return Container(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(height: 56),
+          CafeDetailSectionTitle(title: '통합 검색', showBadge: false),
+          CafeDetailListItem(
+            title: '네이버 통합 검색 바로가기',
+            icon: Icons.manage_search_rounded,
+            subIcon: Icons.launch_rounded,
+            color: Palette.lightGreen,
+            onPressed: () => handleNaverClick(cafeName, context),
+          ),
+          CafeDetailListItem(
+            title: '인스타그램 태그 검색 바로가기',
+            icon: Icons.photo,
+            subIcon: Icons.launch_rounded,
+            color: Palette.lightPurple,
+            onPressed: () => handleInstagramClick(cafeName, context),
+          )
+        ],
+      )
+    );
+  }
+}

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_menu.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_menu.dart
@@ -1,13 +1,18 @@
 import 'package:flutter/material.dart';
-import 'package:mobile_app/constants/color.dart';
 import 'package:mobile_app/constants/enum.dart';
 import 'package:mobile_app/constants/type.dart';
+import 'package:mobile_app/view/cafe_detail/cafe_detail_list_item.dart';
 import 'package:mobile_app/view/cafe_detail/cafe_detail_section_title.dart';
 
 class CafeDetailMenus extends StatelessWidget {
   final List<CafeMetaMenuModel> menus;
+  Iterable<CafeMetaMenuModel> get validMenus => menus.where((menu) => _hasMenu(menu));
 
   CafeDetailMenus({required this.menus});
+
+  bool _hasMenu(CafeMetaMenuModel menu){
+    return menu.name != null && menu.category != null;
+  }
 
   @override
   Widget build(BuildContext context){
@@ -17,40 +22,12 @@ class CafeDetailMenus extends StatelessWidget {
         children: [
           SizedBox(height: 56),
           CafeDetailSectionTitle(title: '시그니쳐 메뉴', showBadge: true),
-          ...menus.map((menu) => CafeDetailMenu(menu: menu)).toList()
-        ],
-      )
-    );
-  }
-}
-
-class CafeDetailMenu extends StatelessWidget {
-  final CafeMetaMenuModel menu;
-
-  CafeDetailMenu({required this.menu});
-
-  @override
-  Widget build(BuildContext context){
-    return Container(
-      margin: EdgeInsets.only(bottom: 20, left: 20),
-      child: Row(
-        children: [
-          Container(
-            width: 48,
-            height: 48,
-            decoration: BoxDecoration(
-                color: Palette.lightBlue,
-                borderRadius: BorderRadius.all(Radius.circular(18))
-            ),
-            child: Icon(GetIcon.name(menu.category!), size: 28, color: Colors.white),
-          ),
-          SizedBox(width: 12),
-          Text(menu.name ?? '',
-              style: TextStyle(
-              color: Palette.darkGray,
-              fontSize: 14,
-              fontWeight: FontWeight.bold
-            ))
+          ...validMenus.map((menu) =>
+              CafeDetailListItem(
+                  title: menu.name ?? '',
+                  icon: GetIcon.name(menu.category!),
+              )
+          )
         ],
       )
     );

--- a/mobile_app/lib/view/common/cafe_operation_status.dart
+++ b/mobile_app/lib/view/common/cafe_operation_status.dart
@@ -1,0 +1,22 @@
+import 'package:mobile_app/constants/type.dart';
+
+mixin CafeOperationStatus {
+  final close = '영업종료';
+  final open = '영업중';
+
+  String? getCafeOperationStatus(CafeMetaOperationHoursModel? hours) {
+    if(hours == null) return null;
+
+    final _now = DateTime.now();
+
+    if(_now.hour < hours.open.hour || _now.hour > hours.close.hour){
+      return close;
+    }else if(_now.hour == hours.close.hour && _now.minute > hours.close.minute){
+      return close;
+    }else if(_now.hour == hours.open.hour && _now.minute < hours.open.minute){
+      return close;
+    } else {
+      return open;
+    }
+  }
+}

--- a/mobile_app/lib/view/common/header.dart
+++ b/mobile_app/lib/view/common/header.dart
@@ -43,7 +43,7 @@ class MainHeader extends StatelessWidget with PreferredSizeWidget, _HeaderSpec {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      backgroundColor: isTableViewMode ? Colors.white : Colors.transparent,
+      backgroundColor: Colors.white,
       elevation: 0,
       iconTheme: IconThemeData(color: Palette.gray),
       title: _logo,
@@ -65,7 +65,7 @@ class BaseHeader extends StatelessWidget with PreferredSizeWidget, _HeaderSpec {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      backgroundColor: Colors.transparent,
+      backgroundColor: Colors.white,
       elevation: 0,
       iconTheme: IconThemeData(color: Palette.gray),
       title: _logo,
@@ -106,7 +106,7 @@ class _DetailHeaderState extends State<DetailHeader> {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-        backgroundColor: Colors.transparent,
+        backgroundColor: Colors.white,
         elevation: 0,
         leading: IconButton(
           color: Palette.gray,

--- a/mobile_app/lib/view/common/map.dart
+++ b/mobile_app/lib/view/common/map.dart
@@ -24,7 +24,12 @@ class _MapState extends State<Map> {
 
   void initState(){
     super.initState();
-    _mapOption = MapOption(loadingDuration: Duration(milliseconds: 450), opacityDuration: Duration(milliseconds: 500), gestureRecognizerOption: _createGestureRecognizers(), markerOption: _createMarkers(location: widget.location, title: widget.title));
+    _mapOption = MapOption(
+        loadingDuration: Duration(milliseconds: 450),
+        opacityDuration: Duration(milliseconds: 500),
+        gestureRecognizerOption: _createGestureRecognizers(),
+        markerOption: _createMarkers(location: widget.location, title: widget.title),
+    );
   }
 
   final Completer<GoogleMapController> _controller = Completer();
@@ -44,7 +49,7 @@ class _MapState extends State<Map> {
             mapType: MapType.normal,
             markers: _mapOption.markerOption,
             initialCameraPosition:
-            CameraPosition(target: widget.location, zoom: 17),
+            CameraPosition(target: widget.location, zoom: 16),
             onMapCreated: (GoogleMapController controller) {
               _controller.complete(controller);
               Future.delayed(


### PR DESCRIPTION
## Changes
- 디자인 수정
  - footer height shadow 고려하여 조정
  - header 상단 가림 현상 수정
  - 지도 크기 조정
- 네이버, 인스타그램 웹뷰 기능 분리
as-is : 상단 카페 기본 정보와 함께 제공
to-be : `통합 검색` 영역 분리

## Developer Test
- iOS Simulator, aOS Emulator
- 기존 동작 유지 테스트

## Screenshots
<img src="https://user-images.githubusercontent.com/40883884/155539220-9c672695-9adf-4573-91c0-4177761b8df1.png" width="300" />

