### PR TITLE
Create android production build workflow

### DIFF
--- a/.github/workflows/ci-mobile-app.yml
+++ b/.github/workflows/ci-mobile-app.yml
@@ -1,5 +1,8 @@
 name: release-mobile
 on:
+  push:
+    tags:
+      - 'mobile-app@*'
   workflow_dispatch:
     inputs:
       branch:
@@ -8,10 +11,109 @@ on:
         default: "master"
 
 jobs:
-  build:
+  init:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout source from branch.
         uses: actions/checkout@master
         with:
           ref: ${{ github.event.inputs.branch }}
+      - name: Notify build start message.
+        uses: 8398a7/action-slack@e74cd4e48f4452e8158dc4f8bcfc780ae6203364
+        with:
+          status: custom
+          fields: commit,author,ref,workflow
+          custom_payload: |
+            {
+              text: `Start workflow run ${process.env.AS_WORKFLOW} on ${process.env.INPUTS_BRANCH}`,
+              attachments: [
+                {
+                  color: 'good',
+                  text: `Start workflow run ${process.env.AS_WORKFLOW}\n${process.env.AS_REF}(${process.env.AS_COMMIT}) by ${process.env.AS_AUTHOR}`,
+                }
+              ]
+            }
+        env:
+          INPUTS_BRANCH: ${{ github.event.inputs.branch }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
+  build-android:
+    needs: [init]
+    runs-on: ubuntu-18.04
+    defaults:
+      run:
+        working-directory: mobile_app
+    steps:
+      - name: Checkout source from branch.
+        uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Decode android signing key.
+        run: echo $SIGNING_KEY | base64 -d > android/app/keystore.jks
+        env:
+          SIGNING_KEY: ${{ secrets.ANDROID_SIGNING_KEY_RELEASE }}
+      - name: Decode android firebase settings.
+        run: |
+          mkdir android/app/google-services
+          mkdir android/app/google-services/release
+          mkdir android/app/google-services/release/values
+          echo $FIREBASE_VALUES | base64 -d > android/app/google-services/release/values/values.xml
+        env:
+          FIREBASE_VALUES: ${{ secrets.FIREBASE_VALUES_ANDROID_RELEASE }}
+      - name: Decode android external api settings.
+        run: |
+          echo $ANDROID_EXTERNAL_API_KEYS | base64 -d > android/Secrets-release.properties
+        env:
+          ANDROID_EXTERNAL_API_KEYS: ${{ secrets.ANDROID_EXTERNAL_API_KEYS_RELEASE }}
+      - name: Setup Java.
+        uses: actions/setup-java@v2.2.0
+        with:
+          distribution: adopt
+          java-version: '8.0.302'
+      - name: Setup Flutter.
+        uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8
+        with:
+          flutter-version: "2.5.2"
+      - name: Install flutter package dependencies.
+        run: flutter pub get
+      - name: Build app bundle.
+        run: flutter build appbundle --release --dart-define APP_STAGE=release
+        env:
+          ALIAS: upload
+          KEY_PATH: keystore.jks
+          SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD_RELEASE }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD_RELEASE }}
+      - name: Upload build artifacts.
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: build-android
+          path: mobile_app/build/app/outputs/bundle/release/*.aab
+      - name: Notify build message.
+        uses: 8398a7/action-slack@e74cd4e48f4452e8158dc4f8bcfc780ae6203364
+        with:
+          status: ${{ job.status }}
+          fields: repo,job,ref,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: always()
+
+  upload-android-artifact:
+    needs: [build-android]
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout source from branch.
+        uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Download build artifacts.
+        uses: actions/download-artifact@v2.0.10
+        with:
+          name: build-android
+      - name: Pass build artifact to Slack.
+        uses: MeilCli/slack-upload-file@f8f4f6dbe44bb99b36c16a2774836022ffe56fed
+        with:
+          slack_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+          channels: ${{ secrets.SLACK_CHANNELS }}
+          file_path: app-release.aab
+          file_name: app-release.aab
+          file_type: auto


### PR DESCRIPTION
## Summary

`chore/mobile-app/release-ci` 브랜치에 있던 내용을 분리하여 적용합니다.

## Details

- `mobile_app` Android, release stage 를 빌드하는 github actions workflow를 추가합니다.
