### PR TITLE
fix: change detail-footer widget Positioned to AnimatedPosition

### DIFF
--- a/mobile_app/lib/constants/color.dart
+++ b/mobile_app/lib/constants/color.dart
@@ -12,6 +12,7 @@ class Palette {
   static const darkGray = Color.fromRGBO(30, 30, 30, 1.0);
   static const gray = Color.fromRGBO(166, 166, 166, 1.0);
   static const lightGray = Color.fromRGBO(240, 240, 240, 1.0);
+  static const lightGray50 = Color.fromRGBO(240, 240, 240, 0.5);
 
   /*Red*/
   static const red = Color.fromRGBO(242, 82, 82, 1.0);

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_body_content.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_body_content.dart
@@ -62,10 +62,15 @@ class _DetailBodyContentState extends State<DetailBodyContent> {
   }
   void _handleFooterOffset(double scrollDelta, double offset){
     if(!_hasMetadata) return;
+    final isScrollingToDown = scrollDelta > 0;
+    final isScrollingToUp =  scrollDelta < 0;
 
     setState(() {
-        if(offset < _footerHeight){
-          footerOffset = offset - _footerHeight;
+        if(0 < offset && offset < _footerHeight && isScrollingToDown){
+          footerOffset = 0;
+        }
+        if(offset <= 0 && isScrollingToUp){
+          footerOffset = - _footerHeight;
         }
     });
   }
@@ -114,9 +119,10 @@ class _DetailBodyContentState extends State<DetailBodyContent> {
             ),
           ),
         ),
-        Positioned(
+        AnimatedPositioned(
           bottom: footerOffset,
           left: 0,
+          duration: Duration(milliseconds: 150),
           child: CafeDetailFooter(
             cafeId: cafe.id,
             onMenuScroll: _hasMenus ? _handleMenuScroll : null,

--- a/mobile_app/lib/view/cafe_detail/cafe_detail_footer.dart
+++ b/mobile_app/lib/view/cafe_detail/cafe_detail_footer.dart
@@ -19,10 +19,10 @@ class CafeDetailFooter extends StatelessWidget {
       decoration: BoxDecoration(
           color: Palette.whiteTransparentBG,
           boxShadow:  [BoxShadow(
-            color: Palette.lightGray,
-            spreadRadius: 4,
-            blurRadius: 6,
-            offset: Offset(0, 2),
+            color: Palette.lightGray50,
+            spreadRadius: 1,
+            blurRadius: 2,
+            offset: Offset(0, -4),
           )],
       ),
       child: Row(

--- a/mobile_app/lib/view/common/button/custom_icon_button.dart
+++ b/mobile_app/lib/view/common/button/custom_icon_button.dart
@@ -16,8 +16,8 @@ class CustomIconButton extends StatelessWidget {
       height: size.height,
       padding: size.padding,
       child: Container(
-        margin: EdgeInsets.symmetric(horizontal: 10),
-        constraints: BoxConstraints(maxHeight: 40, maxWidth: 40),
+        margin: EdgeInsets.symmetric(horizontal: 6),
+        constraints: BoxConstraints(maxHeight: 44, maxWidth: 44),
         child: ElevatedButton(
           style: ButtonStyle(
             padding: MaterialStateProperty.all(EdgeInsets.all(0)),


### PR DESCRIPTION
## Background
- [애플 앱 심사 reject 사유](https://appstoreconnect.apple.com/apps/1582353861/appstore/reviewsubmissions) : 디테일 페이지에서 footer 안의 버튼이 완전하게 노출되지 않는 경우가 있다.
  - 원인 : footer가 노출되는 플로우를 offset에 맞추다보니 footer height 만큼 내려가지 않으면 반쯤 노출되는 모습을 띔. (-> 애플이 문제시한 부분)
  - 해결 : offset 이 일정 영역안에 진입했을 때 = 0(보임) or = -height (숨김) 으로 변경 (-> 완전히 보이거나 완전히 숨거나 둘 중 하나)

## Developer Test
- aOS, iOS 기기 동작 테스트 완료

**as-is**
<video src="https://user-images.githubusercontent.com/40883884/160244771-b7add0dd-6536-4f7f-89e5-0ba83bd08c79.mov
" />

**to-be**
<video src="https://user-images.githubusercontent.com/40883884/160244744-6f42db26-58d8-479b-be71-02e0039138e6.mov" />


