### PR TITLE
hotfix: declare the android:exported attribute

### DIFF
--- a/mobile_app/android/app/src/main/AndroidManifest.xml
+++ b/mobile_app/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="false">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
@@ -52,6 +53,6 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-    </application>
+   </application>
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mobile_app
 description: A new Flutter project.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 1.5.0+16
+version: 1.5.0+17
 environment:
   sdk: ">=2.14.0 <3.0.0"
 flutter:


### PR DESCRIPTION
## Release Notes
- declare the [android:exported](https://developer.android.com/guide/topics/manifest/activity-element#exported) attribute