### PR TITLE
fix: set android:exported to true

### DIFF
--- a/mobile_app/android/app/src/main/AndroidManifest.xml
+++ b/mobile_app/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize"
-            android:exported="false">
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
@@ -53,6 +53,6 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-   </application>
+    </application>
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
## Changes
```
// AndroidManifest.xml
<intent-filter>
    <action android:name="android.intent.action.MAIN"/>
    <category android:name="android.intent.category.LAUNCHER"/>
</intent-filter>
```
intent-filter 내 cateogy 로 `LAUNCHER` 를 사용하고 있기 때문에 exported = true 로 세팅해야합니다.

## Document
- [android developer guide](https://developer.android.com/about/versions/12/behavior-changes-12#exported)

## Developer Test
1. success case (exported = true)
(a) android 12
![Screen Shot 2022-04-04 at 9 16 12 PM](https://user-images.githubusercontent.com/40883884/161567676-d8ae3947-cd40-4e7e-90b9-c5bf1612d4f9.png)

(b) android 12
![Screen Shot 2022-04-04 at 9 19 43 PM](https://user-images.githubusercontent.com/40883884/161567407-02664725-79fd-4aa7-9a0b-c6ee4186df18.png)

2. fail case (exported = false) 이슈재현
(a) android 12
![Screen Shot 2022-04-04 at 9 17 49 PM](https://user-images.githubusercontent.com/40883884/161567913-5ff65a52-afbe-41ee-b77e-f64b6e0d9ade.png)


(b) android 11
![Screen Shot 2022-04-04 at 9 12 23 PM](https://user-images.githubusercontent.com/40883884/161568011-5c5816c8-8cd8-4fa8-b6b0-7b4a6aedb62e.png)




